### PR TITLE
Feature/45107 ft intermittent failure

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/DeleteEventGridSubscriptionToD365WebhookTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/DeleteEventGridSubscriptionToD365WebhookTest.cs
@@ -45,7 +45,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             HttpResponseMessage apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, null);
             Assert.AreEqual(200, (int)apiStubResponse.StatusCode, $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-
+            await Task.Delay(30000);
             HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
             Assert.AreEqual(202, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
@@ -71,6 +71,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             D365Payload.InputParameters[0].Value.FormattedValues[0].Value = "Inactive";
             requestTime = DateTime.UtcNow;
 
+            await Task.Delay(30000);
             apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
             Assert.AreEqual(202, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
@@ -97,6 +98,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             D365Payload.InputParameters[0].Value.FormattedValues[0].Value = "Active";
             requestTime = DateTime.UtcNow;
 
+            await Task.Delay(30000);
             apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
             Assert.AreEqual(202, (int)apiResponse.StatusCode, $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -437,7 +437,7 @@ stages:
 
   - stage: QAdeploy
     displayName: QAdeploy (inc terraform, webapp deploy)
-   # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     jobs:
       - deployment: QADeployApp
         displayName: QA - deploy terraform and dotnet App

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -437,7 +437,7 @@ stages:
 
   - stage: QAdeploy
     displayName: QAdeploy (inc terraform, webapp deploy)
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
+   # condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'),startsWith(variables['Build.SourceBranch'], 'refs/heads/release/')))
     jobs:
       - deployment: QADeployApp
         displayName: QA - deploy terraform and dotnet App


### PR DESCRIPTION
We have instigated on DeleteEventGridSubscription FT intermittent failure, As in this functional test case we are doing creation, InActive and Active operation, event grid try to process next operation event previous operation is not completed, in case of same subscription id. So we have added an interval of 30-sec delays in each operation.