### PR TITLE
Correct logging level of non AVCS Data event processing

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
@@ -67,7 +67,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         }
 
         [Test]
-        public async Task WhenInvalidBusinessUnitInRequest_ThenReceiveSuccessfulResponse()
+        public async Task WhenDiscardedBusinessUnitInRequest_ThenReceiveSuccessfulResponse()
         {
             CancellationToken cancellationToken = CancellationToken.None;
             CloudEvent cloudEvent = new("test", "test", new object());
@@ -84,6 +84,8 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
             ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
 
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
+            Assert.IsNull(result.Errors);
+            A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(A<CloudEvent>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).MustNotHaveHappened();
         }
 
 
@@ -105,6 +107,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
             Assert.IsNull(result.Errors);
+            A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(A<CloudEvent>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).MustHaveHappenedOnceExactly();
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
@@ -83,7 +83,6 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
 
-            Assert.AreEqual("Invalid business unit in an event.", result.Errors.Single().Description);
             Assert.AreEqual(HttpStatusCode.OK, result.StatusCode);
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Logging/EventIds.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Logging/EventIds.cs
@@ -177,9 +177,9 @@ namespace UKHO.ExternalNotificationService.Common.Logging
         /// </summary>
         FssEventDataMappingCompleted = 900043,
         /// <summary>
-        /// 900044 -  Request invalid business unit for external notification service webhook post endpoint.
+        /// 900044 -  File share service event data discarded for business unit.
         /// </summary>
-        FssEventDataWithInvalidBusinessUnit = 900044,
+        FssEventDataDiscardedForBusinessUnit = 900044,
         /// <summary>
         /// 900045 -  External notification service event publish started.
         /// </summary>


### PR DESCRIPTION
> The ENS live is logging a lot of errors. I suspect that this is mostly a case of incorrect logging level (e.g. http://kibana.ukho.gov.uk/app/kibana#/doc/*/live_externalnotificationservice-2022.04/logevent?id=s77t_n8BUNynH1a9FRwL&_g=()). Could someone look into the logs being raised and ensure that they are appropriate logging levels (e.g. receiving an FSS Files Published event for a business unit that isn’t AVCS Data, isn’t an error).
> Many thanks
> Martin Rock-Evans

Addressed by not treating this situation as an error and rewording the informational log message.