### PR TITLE
Fix to allow negative Latitude & Longitude values

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -146,7 +146,6 @@ This CVE applies to python and this is a false positive cve for our application 
    False positive because this CVE applies to a Javascript module named Async (https://github.com/caolan/async) which has nothing to do with Serilog.Sinks.Async apart from the word Async.
    ]]>
     </notes>
-    <packageUrl regex="true">^pkg:generic/Serilog\.Sinks\.Async@.*$</packageUrl>
     <cve>CVE-2021-43138</cve>
   </suppress>
 </suppressions>

--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -137,4 +137,16 @@ This CVE applies to python and this is a false positive cve for our application 
     </notes>
     <cve>CVE-2021-33880</cve>
   </suppress>
+  <suppress>
+    <notes>
+      <![CDATA[
+   file name: Serilog.Sinks.Async.dll
+   https://nvd.nist.gov/vuln/detail/CVE-2021-43138
+   A vulnerability exists in Async through 3.2.1 (fixed in 3.2.2) , which could let a malicious user obtain privileges via the mapValues() method.
+   False positive because this CVE applies to a Javascript module named Async (https://github.com/caolan/async) which has nothing to do with Serilog.Sinks.Async apart from the word Async.
+   ]]>
+    </notes>
+    <packageUrl regex="true">^pkg:generic/Serilog\.Sinks\.Async@.*$</packageUrl>
+    <cve>CVE-2021-43138</cve>
+  </suppress>
 </suppressions>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
@@ -179,7 +179,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidScsJObjectBody_ThenOkStatusIsReturned()
         {
-            const string subject = "NO4F1617";
+            const string subject = "GB53496A";
             JObject ensWebhookJson = ScsEventBody;            
             await StubApiClient.PostStubApiCommandToReturnStatusAsync(ensWebhookJson, subject, null);            
             DateTime startTime = DateTime.UtcNow;

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/Helper/ScsEventDataBase.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/Helper/ScsEventDataBase.cs
@@ -12,7 +12,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.Helper
             var ensWebhookJson = JObject.Parse(@"{""Type"":""uk.gov.UKHO.catalogue.productUpdated.v1""}");
             ensWebhookJson["Source"] = $"{testConfigure.ScsSource}";
             ensWebhookJson["Id"] = "0d2f05f5-3691-476a-9011-6007bcaa9cbf";
-            ensWebhookJson["Subject"] = "NO4F1617";
+            ensWebhookJson["Subject"] = "GB53496A";
             ensWebhookJson["DataContentType"] = "application/json";
             ensWebhookJson["Data"] = JObject.FromObject(GetScsEventData());
 
@@ -24,14 +24,15 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.Helper
             return new ScsEventData()
             {
                 ProductType = "ENC S57",
-                ProductName = "NO4F1617",
+                ProductName = "GB53496A",
                 EditionNumber = 15,
                 UpdateNumber = 18,
                 BoundingBox = new ProductBoundingBox {
-                                    NorthLimit =63.25,
-                                    SouthLimit =63,
-                                    EastLimit =8,
-                                    WestLimit= 7.75 },
+                                    NorthLimit = 53.7485,
+                                    SouthLimit = 53.7197583,
+                                    EastLimit = -0.2199796,
+                                    WestLimit= -0.3640183
+                },
                 Status = new ProductUpdateStatus {
                                     StatusDate = DateTime.UtcNow,
                                     IsNewCell = false,

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/BaseClass/CustomCloudEventBase.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/BaseClass/CustomCloudEventBase.cs
@@ -11,7 +11,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.BaseClass
     {
         public static CustomCloudEvent GetCustomCloudEvent()
         {
-            return new CustomCloudEvent()
+            return new CustomCloudEvent
             {
                 Type = "uk.gov.UKHO.FileShareService.NewFilesPublished.v1",
                 Source = "https://files.admiralty.co.uk",
@@ -29,6 +29,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.BaseClass
             {
                 Href = @"https://files.admiralty.co.uk/batch/83d08093-7a67-4b3a-b431-92ba42feaea0"
             };
+
             Link linkBatchStatus = new()
             {
                 Href = @"https://files.admiralty.co.uk/batch/83d08093-7a67-4b3a-b431-92ba42feaea0/status"
@@ -45,38 +46,42 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.BaseClass
                 BatchStatus = linkBatchStatus
             };
 
-            return new FssEventData()
+            return new FssEventData
             {
                 Links = links,
                 BusinessUnit = "AVCSData",
-                Attributes = new List<Attribute> { },
+                Attributes = new List<Attribute>(),
                 BatchId = "83d08093-7a67-4b3a-b431-92ba42feaea0",
                 BatchPublishedDate = DateTime.UtcNow,
-                Files = new File[] {new() { MIMEType= "application/zip",
-                                                                    FileName= "AVCS_S631-1_Update_Wk45_21_Only.zip",
-                                                                    FileSize=99073923,
-                                                                    Hash="yNpJTWFKhD3iasV8B/ePKw==",
-                                                                    Attributes=new List<Attribute> {},
-                                                                    Links = fileLinks   }}
+                Files = new File[] {
+                    new() {
+                        MIMEType= "application/zip",
+                        FileName= "AVCS_S631-1_Update_Wk45_21_Only.zip",
+                        FileSize=99073923,
+                        Hash="yNpJTWFKhD3iasV8B/ePKw==",
+                        Attributes=new List<Attribute>(),
+                        Links = fileLinks
+                    }
+                }
             };
         }
 
         public static ScsEventData GetScsEventData()
         {
-            return new ScsEventData()
+            return new ScsEventData
             {
                 ProductType = "ENC S57",
-                ProductName = "NO4F1615",
+                ProductName = "GB53496A",
                 EditionNumber = 15,
                 UpdateNumber = 18,
-                BoundingBox = new ProductBoundingBox()
+                BoundingBox = new ProductBoundingBox
                 {
-                    NorthLimit = 63.25,
-                    SouthLimit = 63,
-                    EastLimit = 8,
-                    WestLimit = 7.75
+                    NorthLimit = 53.7485,
+                    SouthLimit = 53.7197583,
+                    EastLimit = -0.2199796,
+                    WestLimit = -0.3640183
                 },
-                Status = new ProductUpdateStatus()
+                Status = new ProductUpdateStatus
                 {
                     StatusDate = DateTime.UtcNow,
                     IsNewCell = false,

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
@@ -21,7 +21,6 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             _scsEventDataValidator = new ScsEventDataValidator();
         }
 
-        #region ProductType
         [Test]
         public void WhenNullProductTypeInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -33,9 +32,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "ProductType cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region productName
         [Test]
         public void WhenNullProductNameInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -47,9 +44,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "ProductName cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region EditionNumber
         [Test]
         public void WhenEditionNumberLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -61,9 +56,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "EditionNumber cannot be less than zero or blank."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region UpdateNumber
         [Test]
         public void WhenUpdateNumberLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -75,9 +68,19 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "UpdateNumber cannot be less than zero or blank."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region BoundingBox
+        [Test]
+        public void WhenFileSizeLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
+        {
+            _fakeScsEventData.FileSize = -1;
+
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            result.ShouldHaveValidationErrorFor("FileSize");
+
+            Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "FileSize cannot be less than zero or blank."));
+            Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+        }
+
         [Test]
         public void WhenNullBoundingBoxInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -89,65 +92,63 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "BoundingBox cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region NorthLimit
-        [Test]
-        public void WhenNorthLimitLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
+        [TestCase(-90.1, false)]
+        [TestCase(-90.0, true)]
+        [TestCase(0, true)]
+        [TestCase(90, true)]
+        [TestCase(90.1, false)]
+        public void WhenNorthLimitHasValue_ReceiveCorrectResponse(double value, bool shouldBeValid)
         {
-            _fakeScsEventData.BoundingBox.NorthLimit = -1;
+            _fakeScsEventData.BoundingBox.NorthLimit = value;
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
-            result.ShouldHaveValidationErrorFor("NorthLimit");
 
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "NorthLimit cannot be less than zero or blank."));
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+            CheckLatLongResult(nameof(ProductBoundingBox.NorthLimit), "90", result, shouldBeValid);
         }
-        #endregion
 
-        #region SouthLimit
-        [Test]
-        public void WhenSouthLimitLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
+        [TestCase(-90.1, false)]
+        [TestCase(-90.0, true)]
+        [TestCase(0, true)]
+        [TestCase(90, true)]
+        [TestCase(90.1, false)]
+        public void WhenSouthLimitHasValue_ReceiveCorrectResponse(double value, bool shouldBeValid)
         {
-            _fakeScsEventData.BoundingBox.SouthLimit = -1;
+            _fakeScsEventData.BoundingBox.SouthLimit = value;
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
-            result.ShouldHaveValidationErrorFor("SouthLimit");
 
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "SouthLimit cannot be less than zero or blank."));
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+            CheckLatLongResult(nameof(ProductBoundingBox.SouthLimit), "90", result, shouldBeValid);
         }
-        #endregion
 
-        #region EastLimit
-        [Test]
-        public void WhenEastLimitLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
+        [TestCase(-180.1, false)]
+        [TestCase(-180.0, true)]
+        [TestCase(0, true)]
+        [TestCase(180, true)]
+        [TestCase(180.1, false)]
+        public void WhenEastLimitHasValue_ReceiveCorrectResponse(double value, bool shouldBeValid)
         {
-            _fakeScsEventData.BoundingBox.EastLimit = -1;
+            _fakeScsEventData.BoundingBox.EastLimit = value;
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
-            result.ShouldHaveValidationErrorFor("EastLimit");
 
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "EastLimit cannot be less than zero or blank."));
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+            CheckLatLongResult(nameof(ProductBoundingBox.EastLimit), "180", result, shouldBeValid);
         }
-        #endregion
 
-        #region WestLimit
-        [Test]
-        public void WhenWestLimitLessThanZeroInRequest_ThenReceiveSuccessfulResponse()
+        [TestCase(-180.1, false)]
+        [TestCase(-180.0, true)]
+        [TestCase(0, true)]
+        [TestCase(180, true)]
+        [TestCase(180.1, false)]
+        public void WhenWestLimitHasValue_ReceiveCorrectResponse(double value, bool shouldBeValid)
         {
-            _fakeScsEventData.BoundingBox.WestLimit = -1;
+            _fakeScsEventData.BoundingBox.WestLimit = value;
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
-            result.ShouldHaveValidationErrorFor("WestLimit");
 
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "WestLimit cannot be less than zero or blank."));
-            Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+            CheckLatLongResult(nameof(ProductBoundingBox.WestLimit), "180", result, shouldBeValid);
         }
-        #endregion
 
-        #region Status
         [Test]
         public void WhenNullStatusInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -159,9 +160,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "Status cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region StatusDate
         [Test]
         public void WhenNullStatusDateInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -173,9 +172,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "StatusDate cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region StatusName
         [Test]
         public void WhenNullStatusNameInRequest_ThenReceiveSuccessfulResponse()
         {
@@ -187,9 +184,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == "StatusName cannot be blank or null."));
             Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
         }
-        #endregion
 
-        #region ScsEventData
         [Test]
         public void WhenValidRequest_ThenReceiveSuccessfulResponse()
         {
@@ -197,6 +192,21 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
 
             Assert.AreEqual(0, result.Errors.Count);
         }
-        #endregion
+
+        private static void CheckLatLongResult(string property, string limit, TestValidationResult<ScsEventData> result, bool shouldBeValid)
+        {
+            if (shouldBeValid)
+            {
+                Assert.AreEqual(true, result.IsValid);
+                Assert.AreEqual(0, result.Errors.Count);
+            }
+            else
+            {
+                Assert.AreEqual(1, result.Errors.Count);
+                result.ShouldHaveValidationErrorFor(property);
+                Assert.IsTrue(result.Errors.Any(x => x.ErrorMessage == $"{property} should be in the range -{limit}.0 to +{limit}.0."));
+                Assert.IsTrue(result.Errors.Any(x => x.ErrorCode == "OK"));
+            }
+        }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
@@ -104,7 +104,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
-            CheckLatLongResult(nameof(ProductBoundingBox.NorthLimit), "90", result, shouldBeValid);
+            CheckLatLongResult(nameof(ProductBoundingBox.NorthLimit), 90, result, shouldBeValid);
         }
 
         [TestCase(-90.1, false)]
@@ -118,7 +118,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
-            CheckLatLongResult(nameof(ProductBoundingBox.SouthLimit), "90", result, shouldBeValid);
+            CheckLatLongResult(nameof(ProductBoundingBox.SouthLimit), 90, result, shouldBeValid);
         }
 
         [TestCase(-180.1, false)]
@@ -132,7 +132,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
-            CheckLatLongResult(nameof(ProductBoundingBox.EastLimit), "180", result, shouldBeValid);
+            CheckLatLongResult(nameof(ProductBoundingBox.EastLimit), 180, result, shouldBeValid);
         }
 
         [TestCase(-180.1, false)]
@@ -146,7 +146,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
 
             TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
-            CheckLatLongResult(nameof(ProductBoundingBox.WestLimit), "180", result, shouldBeValid);
+            CheckLatLongResult(nameof(ProductBoundingBox.WestLimit), 180, result, shouldBeValid);
         }
 
         [Test]
@@ -193,7 +193,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             Assert.AreEqual(0, result.Errors.Count);
         }
 
-        private static void CheckLatLongResult(string property, string limit, TestValidationResult<ScsEventData> result, bool shouldBeValid)
+        private static void CheckLatLongResult(string property, int limit, TestValidationResult<ScsEventData> result, bool shouldBeValid)
         {
             if (shouldBeValid)
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Validation/ScsEventDataValidator.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Validation/ScsEventDataValidator.cs
@@ -13,69 +13,83 @@ namespace UKHO.ExternalNotificationService.API.Validation
 
     public class ScsEventDataValidator : AbstractValidator<ScsEventData>, IScsEventDataValidator
     {
+        private const int LatitudeLimitDegrees = 180;
+        private const int LongitudeLimitDegrees = 90;
+
         public ScsEventDataValidator()
         {
-            RuleFor(v => v.ProductType).NotNull().NotEmpty()
+            RuleFor(v => v.ProductType)
+                .NotNull().NotEmpty()
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("ProductType cannot be blank or null.");
 
-            RuleFor(v => v.ProductName).NotNull().NotEmpty()
+            RuleFor(v => v.ProductName)
+                .NotNull().NotEmpty()
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("ProductName cannot be blank or null.");
 
-            RuleFor(v => v.EditionNumber).NotEmpty().NotNull().GreaterThanOrEqualTo(0)
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.EditionNumber)
+                .GreaterThanOrEqualTo(0)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("EditionNumber cannot be less than zero or blank.");
 
-            RuleFor(v => v.UpdateNumber).NotEmpty().NotNull().GreaterThanOrEqualTo(0)
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.UpdateNumber)
+                .GreaterThanOrEqualTo(0)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("UpdateNumber cannot be less than zero or blank.");
 
-            RuleFor(v => v.FileSize).NotEmpty().NotNull().GreaterThanOrEqualTo(0)
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.FileSize)
+                .GreaterThanOrEqualTo(0)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("FileSize cannot be less than zero or blank.");
 
-            RuleFor(v => v.BoundingBox).NotNull().NotEmpty()
+            RuleFor(v => v.BoundingBox)
+                .NotNull().NotEmpty()
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("BoundingBox cannot be blank or null.");
 
-            RuleFor(v => v.BoundingBox.NorthLimit).NotEmpty().NotNull().GreaterThanOrEqualTo(0).OverridePropertyName("NorthLimit")
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.BoundingBox.NorthLimit)
+                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
+                .OverridePropertyName("NorthLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage("NorthLimit cannot be less than zero or blank.");
+                .WithMessage($"NorthLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
 
-            RuleFor(v => v.BoundingBox.SouthLimit).NotEmpty().NotNull().GreaterThanOrEqualTo(0).OverridePropertyName("SouthLimit")
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.BoundingBox.SouthLimit)
+                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
+                .OverridePropertyName("SouthLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage("SouthLimit cannot be less than zero or blank.");
+                .WithMessage($"SouthLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
 
-            RuleFor(v => v.BoundingBox.EastLimit).NotEmpty().NotNull().GreaterThanOrEqualTo(0).OverridePropertyName("EastLimit")
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.BoundingBox.EastLimit)
+                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
+                .OverridePropertyName("EastLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage("EastLimit cannot be less than zero or blank.");
+                .WithMessage($"EastLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
 
-            RuleFor(v => v.BoundingBox.WestLimit).NotEmpty().NotNull().GreaterThanOrEqualTo(0).OverridePropertyName("WestLimit")
-                .Must(ru => ru >= 0)
+            RuleFor(v => v.BoundingBox.WestLimit)
+                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
+                .OverridePropertyName("WestLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage("WestLimit cannot be less than zero or blank.");
+                .WithMessage($"WestLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
 
             RuleFor(v => v.Status).NotNull().NotEmpty()
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("Status cannot be blank or null.");
 
-            RuleFor(v => v.Status.StatusDate).NotNull().NotEmpty().OverridePropertyName("StatusDate")
+            RuleFor(v => v.Status.StatusDate)
+                .NotNull().NotEmpty()
+                .OverridePropertyName("StatusDate")
                 .When(x => x.Status != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("StatusDate cannot be blank or null.");
 
-            RuleFor(v => v.Status.StatusName).NotNull().NotEmpty().OverridePropertyName("StatusName")
+            RuleFor(v => v.Status.StatusName)
+                .NotNull().NotEmpty()
+                .OverridePropertyName("StatusName")
                 .When(x => x.Status != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
                 .WithMessage("StatusName cannot be blank or null.");

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Validation/ScsEventDataValidator.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Validation/ScsEventDataValidator.cs
@@ -13,8 +13,8 @@ namespace UKHO.ExternalNotificationService.API.Validation
 
     public class ScsEventDataValidator : AbstractValidator<ScsEventData>, IScsEventDataValidator
     {
-        private const int LatitudeLimitDegrees = 180;
-        private const int LongitudeLimitDegrees = 90;
+        private const double LatitudeLimitDegrees = 90;
+        private const double LongitudeLimitDegrees = 180;
 
         public ScsEventDataValidator()
         {
@@ -49,32 +49,32 @@ namespace UKHO.ExternalNotificationService.API.Validation
                 .WithMessage("BoundingBox cannot be blank or null.");
 
             RuleFor(v => v.BoundingBox.NorthLimit)
-                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
+                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
                 .OverridePropertyName("NorthLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage($"NorthLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
+                .WithMessage($"NorthLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
 
             RuleFor(v => v.BoundingBox.SouthLimit)
-                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
+                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
                 .OverridePropertyName("SouthLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage($"SouthLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
+                .WithMessage($"SouthLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
 
             RuleFor(v => v.BoundingBox.EastLimit)
-                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
+                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
                 .OverridePropertyName("EastLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage($"EastLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
+                .WithMessage($"EastLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
 
             RuleFor(v => v.BoundingBox.WestLimit)
-                .InclusiveBetween(-LatitudeLimitDegrees, LatitudeLimitDegrees)
+                .InclusiveBetween(-LongitudeLimitDegrees, LongitudeLimitDegrees)
                 .OverridePropertyName("WestLimit")
                 .When(x => x.BoundingBox != null)
                 .WithErrorCode(HttpStatusCode.OK.ToString())
-                .WithMessage($"WestLimit should be in the range -{LatitudeLimitDegrees}.0 to +{LatitudeLimitDegrees}.0.");
+                .WithMessage($"WestLimit should be in the range -{LongitudeLimitDegrees}.0 to +{LongitudeLimitDegrees}.0.");
 
             RuleFor(v => v.Status).NotNull().NotEmpty()
                 .WithErrorCode(HttpStatusCode.OK.ToString())


### PR DESCRIPTION
The following `uk.gov.UKHO.catalogue.productUpdated.v1` event does not currently pass validation in ENS and is discarded due to the negative longitude values:
```
{
  "specversion": "1.0",
  "datacontenttype": "application/json",
  "id": "12f8438c-099f-4dba-bf2e-38ec38e9a810",
  "subject": "GB53496A",
  "time": "2022-04-14T14:01:57.8319365Z",
  "type": "uk.gov.UKHO.catalogue.productUpdated.v1",
  "source": "https://salescatalogueservice.ukho.gov.uk",
  "data": {
    "boundingBox": {
      "eastLimit": -0.2199796,
      "northLimit": 53.7485,
      "southLimit": 53.7197583,
      "westLimit": -0.3640183
    },
    "editionNumber": 20,
    "fileSize": 162744,
    "isPermitUpdateRequired": false,
    "productName": "GB53496A",
    "productType": "ENC S57",
    "replaces": [],
    "status": {
      "isNewCell": false,
      "statusDate": "2021-01-08T00:00:00Z",
      "statusName": "New Edition"
    },
    "updateNumber": 0
  }
}
```

This PR fixes validation to allow Latitude values in the range -90 to +90 and Longitude values in the range -180 to +180.

![image](https://user-images.githubusercontent.com/91606761/163988642-8d58e1ad-5d79-45e7-b6a9-001b2f0b8041.png)
