### PR TITLE
46685 - Fixed host id for webjob host

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/Program.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/Program.cs
@@ -1,5 +1,6 @@
 ﻿using Azure.Identity;
 using Microsoft.Azure.WebJobs.Host;
+using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
@@ -137,6 +138,13 @@ namespace UKHO.ExternalNotificationService.SubscriptionService
                   b.AddAzureStorageCoreServices();
                   b.AddAzureStorageQueues();
                   b.AddAzureStorageBlobs();
+
+                  //Use fixed host id
+                  string hostId = s_configurationBuilder.GetValue<string>("WebjobHostId");
+                  if (!string.IsNullOrWhiteSpace(hostId))
+                  {
+                      b.UseHostId(hostId);
+                  }
               });
 
             return hostBuilder;

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/appsettings.json
@@ -1,5 +1,6 @@
 {
     "APPINSIGHTS_INSTRUMENTATIONKEY": "",
+    "WebjobHostId": "f622dc51b5362c40db49e2ffc2a44535",
     "Logging": {
         "LogLevel": {
             "Default": "Debug",


### PR DESCRIPTION
Code changes to use a fixed host id for webjob host.

The latest host id used in Live by webjob is "**f622dc51b5362c40db49e2ffc2a44535**" and we want this host id to be maintained.