### PR TITLE
Update .NET SDK to 6.0.417 (#91)

### DIFF
--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.36.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.25" />
     <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -10,12 +10,12 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.5.0" />
     <PackageReference Include="FluentValidation" Version="10.4.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.24" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.24" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.24" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="6.0.25" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.25" />
     <PackageReference Include="Microsoft.Azure.KeyVault" Version="3.0.5" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.24" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="6.0.25" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="2.0.0" />
   </ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="12.19.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Azure.EventGrid" Version="3.2.1" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.24" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="6.0.25" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.23242.1" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
@@ -16,7 +16,7 @@
     <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.24" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="6.0.25" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="6.0.0" />
     <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
     <PackageReference Include="Serilog" Version="2.12.0" />

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.416",
+    "version": "6.0.417",
     "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
* Update .NET SDK

Update .NET SDK to version 6.0.417.

---
updated-dependencies:
- dependency-name: Microsoft.NET.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...



* Bump .NET NuGet packages with 6 updates

Bump .NET NuGet packages with 6 updates:

Update Microsoft.AspNetCore.Authentication.JwtBearer from 6.0.24 to 6.0.25. Update Microsoft.AspNetCore.HeaderPropagation from 6.0.24 to 6.0.25. Update Microsoft.AspNetCore.Mvc.NewtonsoftJson from 6.0.24 to 6.0.25. Update Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions from 6.0.24 to 6.0.25. Update Microsoft.Extensions.Http.Polly from 6.0.24 to 6.0.25. Update Microsoft.Extensions.Logging.AzureAppServices from 6.0.24 to 6.0.25.

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Authentication.JwtBearer dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.AspNetCore.HeaderPropagation dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch
- dependency-name: Microsoft.Extensions.Logging.AzureAppServices dependency-type: direct:production update-type: version-update:semver-patch ...



---------