### PR TITLE
Abzu-164809 - Add event publish delay configuration

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
@@ -43,5 +43,8 @@
     },
     "ScsDataMappingConfiguration": {
         "Source": "avcs-contentPublished"
+    },
+    "EventProcessorConfiguration": {
+        "ScsEventPublishDelayInSeconds": 2
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventProcessorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventProcessorTest.cs
@@ -1,15 +1,19 @@
 ﻿using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging;
 using FakeItEasy;
+using FakeItEasy.Configuration;
 using FluentValidation.Results;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using NUnit.Framework;
 using UKHO.ExternalNotificationService.API.Services;
 using UKHO.ExternalNotificationService.API.UnitTests.BaseClass;
+using UKHO.ExternalNotificationService.Common.Configuration;
 using UKHO.ExternalNotificationService.Common.Helpers;
 using UKHO.ExternalNotificationService.Common.Models.EventModel;
 using UKHO.ExternalNotificationService.Common.Models.Request;
@@ -23,6 +27,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         private IScsEventValidationAndMappingService _fakeScsEventValidationAndMappingService;
         private ILogger<ScsEventProcessor> _fakeLogger;
         private IAzureEventGridDomainService _fakeAzureEventGridDomainService;
+        private IOptions<EventProcessorConfiguration> _fakeEventProcessorConfiguration;
         private ScsEventProcessor _scsEventProcessor;
         private CustomCloudEvent _fakeCustomCloudEvent;
         private ScsEventData _fakeScsEventData;
@@ -39,9 +44,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
             _fakeScsEventValidationAndMappingService = A.Fake<IScsEventValidationAndMappingService>();
             _fakeLogger = A.Fake<ILogger<ScsEventProcessor>>();
             _fakeAzureEventGridDomainService = A.Fake<IAzureEventGridDomainService>();
+            _fakeEventProcessorConfiguration = A.Fake<IOptions<EventProcessorConfiguration>>();
+
+            _fakeEventProcessorConfiguration.Value.ScsEventPublishDelayInSeconds = 0;  
 
             _scsEventProcessor = new ScsEventProcessor(_fakeScsEventValidationAndMappingService,
-                                                       _fakeLogger, _fakeAzureEventGridDomainService);
+                                                       _fakeLogger, _fakeAzureEventGridDomainService, _fakeEventProcessorConfiguration);
         }
 
         [Test]
@@ -70,7 +78,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         }
 
         [Test]
-        public async Task WhenValidPayloadInRequest_ThenReceiveSuccessfulResponse()
+       public async Task WhenValidPayloadInRequest_ThenReceiveSuccessfulResponse()
         {
             CancellationToken cancellationToken = CancellationToken.None;
             CloudEvent cloudEvent = new("test", "test", new object());
@@ -87,6 +95,60 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             Assert.That(HttpStatusCode.OK, Is.EqualTo(result.StatusCode));
             Assert.That(result.Errors, Is.Null);
+        }
+
+        [Test]
+        [TestCase(-1, 0)]
+        [TestCase(0, 0)]
+        [TestCase(5, 5)]
+        [TestCase(10, 10)]
+        [TestCase(12, 10)]
+        [TestCase(60, 10)]
+        public async Task WhenValidPayloadInRequestAndConfiguredDelay_ThenReceiveSuccessfulResponse(int configuredDelay, int expectedDelay)
+        {
+            CancellationToken cancellationToken = CancellationToken.None;
+            CloudEvent cloudEvent = new("test", "test", new object());
+
+            _fakeEventProcessorConfiguration.Value.ScsEventPublishDelayInSeconds = configuredDelay; 
+
+            A.CallTo(() => _fakeScsEventValidationAndMappingService.ValidateScsEventData(A<ScsEventData>.Ignored)).Returns(new ValidationResult());
+
+            A.CallTo(() => _fakeScsEventValidationAndMappingService.ScsEventDataMapping(A<CustomCloudEvent>.Ignored, A<string>.Ignored)).Returns(cloudEvent);
+
+            A.CallTo(() => _fakeAzureEventGridDomainService.JsonDeserialize<ScsEventData>(A<object>.Ignored)).Returns(_fakeScsEventData);
+
+            IReturnValueArgumentValidationConfiguration<Task> callToPublishEventAsync = A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken));
+
+            Stopwatch stopwatch = new();
+
+            stopwatch.Start();
+
+            ExternalNotificationServiceProcessResponse result = await _scsEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
+
+            stopwatch.Stop();
+
+            callToPublishEventAsync.MustHaveHappened();
+
+            Assert.That(HttpStatusCode.OK, Is.EqualTo(result.StatusCode));
+            Assert.That(result.Errors, Is.Null);
+
+            Assert.That(stopwatch.ElapsedMilliseconds, Is.GreaterThanOrEqualTo(expectedDelay * 1000));
+        }
+
+        [Test]
+        [TestCase(-1, 0)]
+        [TestCase(0, 0)]
+        [TestCase(5, 5)]
+        [TestCase(10, 10)]
+        [TestCase(12, 10)]
+        [TestCase(60, 10)]
+        public void WhenDelayInMillisecondsIsAccessed_ThenReturnedSuccessfully(int configuredDelay, int expectedDelay)
+        {
+            _fakeEventProcessorConfiguration.Value.ScsEventPublishDelayInSeconds = configuredDelay;
+
+            int result = _scsEventProcessor.DelayInMilliseconds;
+
+            Assert.That(expectedDelay * 1000, Is.EqualTo(result));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/ScsEventProcessor.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/ScsEventProcessor.cs
@@ -1,6 +1,8 @@
-﻿using Azure.Messaging;
+﻿using System;
+using Azure.Messaging;
 using FluentValidation.Results;
 using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
 using System.Collections.Generic;
 using System.Net;
 using System.Threading;
@@ -20,17 +22,25 @@ namespace UKHO.ExternalNotificationService.API.Services
     {
         private readonly IScsEventValidationAndMappingService _scsEventValidationAndMappingService;
         private readonly ILogger<ScsEventProcessor> _logger;
+        private readonly IOptions<EventProcessorConfiguration> _eventProcessorConfiguration;
+
         private List<Error> _errors;
 
         public string EventType => EventProcessorTypes.SCS;
 
+        private const int MinDelay = 0;
+        private const int MaxDelay = 10;
+        public int DelayInMilliseconds => Math.Clamp(_eventProcessorConfiguration.Value.ScsEventPublishDelayInSeconds, MinDelay, MaxDelay) * 1000;
+        
         public ScsEventProcessor(IScsEventValidationAndMappingService scsEventValidationAndMappingService,
                                 ILogger<ScsEventProcessor> logger,
-                                IAzureEventGridDomainService azureEventGridDomainService)
+                                IAzureEventGridDomainService azureEventGridDomainService,
+                                IOptions<EventProcessorConfiguration> eventProcessorConfiguration)
                                : base(azureEventGridDomainService)
         {
             _scsEventValidationAndMappingService = scsEventValidationAndMappingService;
             _logger = logger;
+            _eventProcessorConfiguration = eventProcessorConfiguration;
         }
 
 
@@ -47,8 +57,8 @@ namespace UKHO.ExternalNotificationService.API.Services
             CloudEvent cloudEvent = _scsEventValidationAndMappingService.ScsEventDataMapping(customCloudEvent, correlationId);
             _logger.LogInformation(EventIds.ScsEventDataMappingCompleted.ToEventId(), "Sales catalogue service event data mapping successfully completed for subject:{subject} and _X-Correlation-ID:{correlationId}.", customCloudEvent.Subject, correlationId);
 
-            await PublishEventAsync(cloudEvent, correlationId, cancellationToken);
-
+            await PublishEventWithDelayAsync(cloudEvent, correlationId, DelayInMilliseconds, cancellationToken);
+           
             return ProcessResponse();
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Startup.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Startup.cs
@@ -68,6 +68,7 @@ namespace UKHO.ExternalNotificationService.API
             services.Configure<EventGridDomainConfiguration>(_configuration.GetSection("EventGridDomainConfiguration"));
             services.Configure<FssDataMappingConfiguration>(_configuration.GetSection("FssDataMappingConfiguration"));
             services.Configure<ScsDataMappingConfiguration>(_configuration.GetSection("ScsDataMappingConfiguration"));
+            services.Configure<EventProcessorConfiguration>(_configuration.GetSection("EventProcessorConfiguration"));
 
             services.AddApplicationInsightsTelemetry();
             services.AddLogging(loggingBuilder =>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
@@ -65,5 +65,9 @@
         "ServerURL": "",
         "ServiceName": "",
         "Environment": ""
+    },
+
+    "EventProcessorConfiguration": {
+        "ScsEventPublishDelayInSeconds": 10
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/BaseClass/EventProcessorBase.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/BaseClass/EventProcessorBase.cs
@@ -1,4 +1,5 @@
-﻿using Azure.Messaging;
+﻿using System;
+using Azure.Messaging;
 using System.Threading;
 using System.Threading.Tasks;
 using UKHO.ExternalNotificationService.Common.Helpers;
@@ -22,6 +23,13 @@ namespace UKHO.ExternalNotificationService.Common.BaseClass
         public async Task PublishEventAsync(CloudEvent cloudEvent, string correlationId, CancellationToken cancellationToken = default)
         {
             await _azureEventGridDomainService.PublishEventAsync(cloudEvent, correlationId, cancellationToken);
+        }
+        
+        public async Task PublishEventWithDelayAsync(CloudEvent cloudEvent, string correlationId, int millisecondsDelay,  CancellationToken cancellationToken = default)
+        {
+            Thread.Sleep(Math.Max(0, millisecondsDelay));   
+            
+            await PublishEventAsync(cloudEvent, correlationId, cancellationToken);
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/EventProcessorConfiguration.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/EventProcessorConfiguration.cs
@@ -1,0 +1,10 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace UKHO.ExternalNotificationService.Common.Configuration
+{
+    [ExcludeFromCodeCoverage]
+    public class EventProcessorConfiguration
+    {
+        public int ScsEventPublishDelayInSeconds { get; set; }
+    }
+}


### PR DESCRIPTION
**PR Classification**

This commit introduces a new configuration for controlling the delay before publishing events, aiming to enhance the flexibility and reliability of the event processing system. The key changes include:

**PR Summary**

- Updated `appsettings.json` to include `EventProcessorConfiguration` with a `ScsEventPublishDelayInSeconds` property, initially set to 2, later updated to 10 seconds.
- Modified `ScsEventProcessor.cs` and `ScsEventProcessorTest.cs` to utilize the new configuration, adding necessary `using` directives, a private configuration field, and adjusting the constructor to accept the configuration as a parameter. Also, implemented logic to calculate the delay in milliseconds, ensuring it falls within defined min and max bounds.
- Added `EventProcessorConfiguration.cs` class to define the configuration structure.
- Updated `Startup.cs` to bind the new configuration to the `EventProcessorConfiguration` class, making it available through dependency injection.
- Enhanced testing by adding new test cases in `ScsEventProcessorTest.cs` and `EventProcessorBaseTest.cs` to verify the behavior of the event processor with different configured delays and the successful delay of event publication, respectively.