### PR TITLE
Add ADDS monitoring and Elastic APM integration

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
@@ -46,5 +46,6 @@
     },
     "EventProcessorConfiguration": {
         "ScsEventPublishDelayInSeconds": 2
-    }
+    },
+    "ADDSMonitoringEnabled": false
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Extensions/ServiceCollectionExtensionsTest.cs
@@ -1,0 +1,64 @@
+﻿using System.Collections.Generic;
+using Elastic.Clients.Elasticsearch;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using NUnit.Framework;
+using UKHO.ExternalNotificationService.API.Extensions;
+namespace UKHO.ExternalNotificationService.API.UnitTests.Extensions;
+
+[TestFixture]
+public class ServiceCollectionExtensionsTest
+{
+    private IConfiguration _configuration;
+    private string cloudId = "name:bG9jYWxob3N0JGFiY2QkZWZnaA==";
+    private Dictionary<string, string> _inMemorySettings; 
+
+    [SetUp]
+    public void Setup()
+    {
+        _inMemorySettings = new()
+        {
+            {"ElasticApm:CloudId", cloudId},
+            {"ElasticApm:ApiKey", "test-api-key"},
+            {"ADDSMonitoringEnabled", "true"}
+        };
+    }
+
+    private IConfiguration CreateConfiguration(Dictionary<string, string> inMemorySettings)
+    {
+        return new ConfigurationBuilder()
+            .AddInMemoryCollection(inMemorySettings)
+            .Build();
+    }
+
+    [Test]
+    public void AddElasticSearchClient_ShouldRegisterElasticsearchClient()
+    {
+        ServiceCollection services = new();
+        
+        _configuration = CreateConfiguration(_inMemorySettings);
+
+        services.AddElasticSearchClient(_configuration);
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        ElasticsearchClient elasticsearchClient = serviceProvider.GetService<ElasticsearchClient>();
+        
+        Assert.That(elasticsearchClient != null, "elasticsearchClient should not be null");
+    }
+
+    [Test]
+    public void AddElasticSearchClient_ShouldNotRegisterElasticsearchClient_WhenNotEnabled()
+    {
+        _inMemorySettings["ADDSMonitoringEnabled"] = "false";
+        _configuration = CreateConfiguration(_inMemorySettings);
+
+        ServiceCollection services = new();
+
+        services.AddElasticSearchClient(_configuration);
+
+        ServiceProvider serviceProvider = services.BuildServiceProvider();
+        ElasticsearchClient elasticsearchClient = serviceProvider.GetService<ElasticsearchClient>();
+
+        Assert.That(elasticsearchClient == null, "elasticsearchClient should be null");
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/AddsElasticMonitoringTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/AddsElasticMonitoringTest.cs
@@ -1,0 +1,134 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Elastic.Clients.Elasticsearch;
+using FakeItEasy;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using NUnit.Framework;
+using UKHO.ExternalNotificationService.API.Services;
+using UKHO.ExternalNotificationService.Common.Configuration;
+using UKHO.ExternalNotificationService.Common.Models.Monitoring;
+
+namespace UKHO.ExternalNotificationService.API.UnitTests.Services;
+
+[TestFixture]
+public class AddsElasticMonitoringTest
+{
+    private ILogger<AddsElasticMonitoringService> _fakeLogger;
+    private IOptions<ElasticApmConfiguration> _elasticApmConfiguration;
+    private ElasticsearchClient _fakeElasticSearchClient;
+    private AddsElasticMonitoringService _addsElasticMonitoringService;
+
+    [SetUp]
+    public void SetUp()
+    {
+        _fakeLogger = A.Fake<ILogger<AddsElasticMonitoringService>>();
+        _elasticApmConfiguration = Options.Create(new ElasticApmConfiguration
+        {
+            Environment = "TestEnvironment",
+            IndexName = "TestIndex"
+        });
+        _fakeElasticSearchClient = A.Fake<ElasticsearchClient>();
+        _addsElasticMonitoringService = new AddsElasticMonitoringService(_fakeLogger, _elasticApmConfiguration, _fakeElasticSearchClient);
+    }
+
+    [Test]
+    public async Task StopProcessAsync_ShouldSetElasticDocumentDurationAndIsCompleteTrue()
+    {
+        AddsData addsData = new()
+        {
+            ProductName = "TestProduct",
+            EditionNumber = 1,
+            UpdateNumber = 1,
+            StatusName = "TestStatus",
+            Type = "TestType"
+        };
+
+        string correlationId = "TestCorrelationId";
+
+        ElasticLogDocument document = new()
+        {
+            StartTimestamp = DateTime.UtcNow.AddMinutes(-5), ImmediateRelease = true, Id = "TestDocumentId", IsComplete = false, Duration = null
+        };
+
+        GetResponse<ElasticLogDocument> startProcessResponse = new() { Source = document };
+       
+        A.CallTo(() => _fakeElasticSearchClient.GetAsync(A<Id>.Ignored, A<Action<GetRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .Returns(startProcessResponse);
+
+        Func<ElasticLogDocument, bool> documentMatcher = d =>
+        {
+            Assert.That(d.IsComplete, Is.True, "Is Complete should be true");
+            Assert.That(d.Duration.HasValue,  Is.True, "Duration should not be null");
+            Assert.That(d.Duration ?? 0, Is.GreaterThan(TimeSpan.Zero.Seconds), "Duration should be greater than zero");
+            
+            return true;
+        };
+        
+        await _addsElasticMonitoringService.StopProcessAsync(addsData, correlationId);
+
+        A.CallTo(() => _fakeElasticSearchClient.IndexAsync(A<ElasticLogDocument>.That.Matches(d => documentMatcher(d)), A<Action<IndexRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .MustHaveHappenedOnceExactly();
+
+        A.CallTo(_fakeLogger).Where(call => call.GetArgument<LogLevel>(0) == LogLevel.Information)
+            .MustHaveHappened(2, Times.Exactly);
+    }
+
+    [Test]
+    public async Task StopProcessAsync_ShouldLogWarningWhenProcessIsFailed()
+    {
+        AddsData addsData = new()
+        {
+            ProductName = "TestProduct",
+            EditionNumber = 1,
+            UpdateNumber = 1,
+            StatusName = "TestStatus",
+            Type = "TestType"
+        };
+
+        string correlationId = "TestCorrelationId";
+
+        A.CallTo(() => _fakeElasticSearchClient.GetAsync(A<Id>.Ignored, A<Action<GetRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .ThrowsAsync(new Exception("failed"));
+
+        await _addsElasticMonitoringService.StopProcessAsync(addsData, correlationId);
+
+        A.CallTo(() => _fakeElasticSearchClient.IndexAsync(A<ElasticLogDocument>.Ignored, A<Action<IndexRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+        
+        A.CallTo(_fakeLogger).Where(call => call.GetArgument<LogLevel>(0) == LogLevel.Information)
+            .MustHaveHappened(1, Times.Exactly);
+
+        A.CallTo(_fakeLogger).Where(call => call.GetArgument<LogLevel>(0) == LogLevel.Warning)
+            .MustHaveHappened(1, Times.Exactly);
+    }
+
+    [Test]
+    public async Task StopProcessAsync_ShouldLogWarningWhenElasticsearchClientIsNull()
+    {
+        AddsData addsData = new()
+        {
+            ProductName = "TestProduct",
+            EditionNumber = 1,
+            UpdateNumber = 1,
+            StatusName = "TestStatus",
+            Type = "TestType"
+        };
+
+        string correlationId = "TestCorrelationId";
+
+        _addsElasticMonitoringService = new AddsElasticMonitoringService(_fakeLogger, _elasticApmConfiguration);
+
+        await _addsElasticMonitoringService.StopProcessAsync(addsData, correlationId);
+
+        A.CallTo(() => _fakeElasticSearchClient.IndexAsync(A<ElasticLogDocument>.Ignored, A<Action<IndexRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+
+        A.CallTo(() => _fakeElasticSearchClient.GetAsync(A<Id>.Ignored, A<Action<GetRequestDescriptor<ElasticLogDocument>>>.Ignored, A<CancellationToken>.Ignored))
+            .MustNotHaveHappened();
+
+        A.CallTo(_fakeLogger).Where(call => call.GetArgument<LogLevel>(0) == LogLevel.Warning)
+            .MustHaveHappened(1, Times.Exactly);
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Extensions/ServiceCollectionExtensions.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Extensions/ServiceCollectionExtensions.cs
@@ -1,0 +1,26 @@
+﻿using Elastic.Clients.Elasticsearch;
+using Elastic.Transport;
+using UKHO.ExternalNotificationService.Common.Configuration;
+
+namespace UKHO.ExternalNotificationService.API.Extensions;
+
+public static class ServiceCollectionExtensions
+{
+    public static IServiceCollection AddElasticSearchClient(this IServiceCollection services, IConfiguration configuration)
+    {
+        if (!configuration.GetValue<bool>("ADDSMonitoringEnabled"))
+        {
+            return services;
+        }
+
+        ElasticApmConfiguration elasticApmConfiguration = configuration.GetSection("ElasticApm").Get<ElasticApmConfiguration>
+            () ?? new ElasticApmConfiguration();
+
+        ElasticsearchClientSettings settings = new(elasticApmConfiguration.CloudId,
+            new ApiKey(elasticApmConfiguration.ApiKey));
+
+        services.AddSingleton(new ElasticsearchClient(settings));
+
+        return services;
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/AddsElasticMonitoring.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/AddsElasticMonitoring.cs
@@ -1,0 +1,93 @@
+﻿using System.Security.Cryptography;
+using System.Text;
+using Elastic.Clients.Elasticsearch;
+using Microsoft.Extensions.Options;
+using Newtonsoft.Json;
+using UKHO.ExternalNotificationService.Common.Configuration;
+using UKHO.ExternalNotificationService.Common.Logging;
+using UKHO.ExternalNotificationService.Common.Models.Monitoring;
+
+namespace UKHO.ExternalNotificationService.API.Services;
+
+public class AddsElasticMonitoringService : IAddsMonitoringService
+{
+    private readonly ILogger<AddsElasticMonitoringService> _logger;
+    private readonly ElasticApmConfiguration _elasticApmConfiguration;
+    private readonly ElasticsearchClient? _elasticSearchClient;
+
+    public AddsElasticMonitoringService(ILogger<AddsElasticMonitoringService> logger, IOptions<ElasticApmConfiguration> elasticApmConfiguration, ElasticsearchClient? elasticSearchClient = null)
+    {
+        _logger = logger;
+        _elasticApmConfiguration = elasticApmConfiguration.Value;
+        _elasticSearchClient = elasticSearchClient;
+    }
+    public async Task StopProcessAsync(AddsData addsData, string correlationId, CancellationToken cancellationToken = default)
+    {
+        if (_elasticSearchClient is null)
+        {
+            _logger.LogWarning(EventIds.ElasticsearchClientNotConfigured.ToEventId(), "ElasticsearchClient is not configured, _X-Correlation-ID:{correlationId}.",
+                 correlationId);
+            return;
+        }
+
+        var document = new ElasticLogDocument
+        {
+            Timestamp = DateTime.UtcNow,
+            ProductName = addsData.ProductName,
+            EditionNumber = addsData.EditionNumber,
+            UpdateNumber = addsData.UpdateNumber,
+            StatusName = addsData.StatusName,
+            EventType = addsData.Type,
+            StartTimestamp = null,
+            StopTimestamp = DateTime.UtcNow,
+            Duration = null,
+            IsComplete = false,
+            Environment = _elasticApmConfiguration.Environment,
+            IsAbnormal = true
+        };
+
+        _logger.LogInformation(EventIds.StopAddsElasticMonitoringProcessStart.ToEventId(), "Process to stop ADDS monitoring started for document {document} and _X-Correlation-ID:{correlationId}.",
+            JsonConvert.SerializeObject(document), correlationId);
+
+        document.Id = GetHash(document);
+        try
+        {
+            var startProcess = await _elasticSearchClient.GetAsync<ElasticLogDocument>
+                (document.Id, idx => idx.Index(_elasticApmConfiguration.IndexName), cancellationToken);
+            if (startProcess is { Source: not null })
+            {
+                document.StartTimestamp = startProcess.Source.StartTimestamp;
+                document.StopTimestamp = DateTime.UtcNow;
+                if (document.StartTimestamp != null)
+                {
+                    var duration = document.StopTimestamp.Value -
+                                   document.StartTimestamp.Value;
+                    document.Duration = (int?)duration.TotalSeconds;
+                }
+                document.Timestamp = startProcess.Source.Timestamp;
+                document.IsComplete = true;
+                document.IsAbnormal = false;
+                document.ImmediateRelease = startProcess.Source.ImmediateRelease;
+            }
+            await _elasticSearchClient.IndexAsync(document, idx =>
+                idx.Index(_elasticApmConfiguration.IndexName), cancellationToken);
+
+            _logger.LogInformation(EventIds.StopAddsElasticMonitoringProcessCompleted.ToEventId(), "Process to stop ADDS monitoring completed for document {document} and _X-Correlation-ID:{correlationId}.",
+                JsonConvert.SerializeObject(document), correlationId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(EventIds.StopAddsElasticMonitoringProcessError.ToEventId(), "Process to stop ADDS monitoring failed for document {document} and _X-Correlation-ID:{correlationId} with error:{Message}",
+                JsonConvert.SerializeObject(document), correlationId, ex.Message);
+        }
+    }
+
+    private static string GetHash(ElasticLogDocument request)
+    {
+        byte[] data = Encoding.UTF8.GetBytes(
+            $"{request.ProductName}{request.EditionNumber}{request.UpdateNumber}{ request.StatusName}");
+        byte[] hashBytes = SHA256.HashData(data);
+
+        return BitConverter.ToString(hashBytes).Replace("-", "");
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/IAddsMonitoringService.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/IAddsMonitoringService.cs
@@ -1,0 +1,8 @@
+﻿using UKHO.ExternalNotificationService.Common.Models.Monitoring;
+
+namespace UKHO.ExternalNotificationService.API.Services;
+
+public interface IAddsMonitoringService
+{
+    Task StopProcessAsync(AddsData addsData, string correlationId, CancellationToken cancellationToken);
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/ScsEventProcessor.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Services/ScsEventProcessor.cs
@@ -13,6 +13,7 @@ using UKHO.ExternalNotificationService.Common.Configuration;
 using UKHO.ExternalNotificationService.Common.Helpers;
 using UKHO.ExternalNotificationService.Common.Logging;
 using UKHO.ExternalNotificationService.Common.Models.EventModel;
+using UKHO.ExternalNotificationService.Common.Models.Monitoring;
 using UKHO.ExternalNotificationService.Common.Models.Request;
 using UKHO.ExternalNotificationService.Common.Models.Response;
 
@@ -23,6 +24,9 @@ namespace UKHO.ExternalNotificationService.API.Services
         private readonly IScsEventValidationAndMappingService _scsEventValidationAndMappingService;
         private readonly ILogger<ScsEventProcessor> _logger;
         private readonly IOptions<EventProcessorConfiguration> _eventProcessorConfiguration;
+        private readonly bool _addsMonitoringEnabled;
+        private readonly IAddsMonitoringService _addsElasticMonitoringService;
+
 
         private List<Error> _errors = [];
 
@@ -35,12 +39,17 @@ namespace UKHO.ExternalNotificationService.API.Services
         public ScsEventProcessor(IScsEventValidationAndMappingService scsEventValidationAndMappingService,
                                 ILogger<ScsEventProcessor> logger,
                                 IAzureEventGridDomainService azureEventGridDomainService,
-                                IOptions<EventProcessorConfiguration> eventProcessorConfiguration)
+                                IOptions<EventProcessorConfiguration> eventProcessorConfiguration,
+                                IConfiguration configuration,
+                                IAddsMonitoringService addsElasticMonitoringService)
                                : base(azureEventGridDomainService)
         {
             _scsEventValidationAndMappingService = scsEventValidationAndMappingService;
             _logger = logger;
             _eventProcessorConfiguration = eventProcessorConfiguration;
+            _addsElasticMonitoringService = addsElasticMonitoringService;
+
+            _addsMonitoringEnabled = configuration.GetValue<bool>("ADDSMonitoringEnabled");
         }
 
 
@@ -58,7 +67,19 @@ namespace UKHO.ExternalNotificationService.API.Services
             _logger.LogInformation(EventIds.ScsEventDataMappingCompleted.ToEventId(), "Sales catalogue service event data mapping successfully completed for subject:{subject} and _X-Correlation-ID:{correlationId}.", customCloudEvent.Subject, correlationId);
 
             await PublishEventWithDelayAsync(cloudEvent, correlationId, DelayInMilliseconds, cancellationToken);
-           
+
+            if (_addsMonitoringEnabled)
+            {
+                await _addsElasticMonitoringService.StopProcessAsync(new AddsData
+                {
+                    EditionNumber = candidate.Data?.EditionNumber ?? 0,
+                    ProductName = candidate.Data?.ProductName ?? string.Empty,
+                    UpdateNumber = candidate.Data?.UpdateNumber ?? 0,
+                    StatusName = candidate.Data?.Status.StatusName ?? string.Empty,
+                    Type = ScsDataMappingValueConstant.Type
+                }, correlationId, cancellationToken);
+            }
+
             return ProcessResponse();
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Startup.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Startup.cs
@@ -26,6 +26,10 @@ using UKHO.ExternalNotificationService.Common.Repository;
 using UKHO.ExternalNotificationService.Common.Storage;
 using UKHO.Logging.EventHubLogProvider;
 using Elastic.Apm.AspNetCore;
+using Elastic.Clients.Elasticsearch;
+using Elastic.Transport;
+using UKHO.ExternalNotificationService.API.Extensions;
+using System.Configuration;
 
 namespace UKHO.ExternalNotificationService.API
 {
@@ -69,6 +73,7 @@ namespace UKHO.ExternalNotificationService.API
             services.Configure<FssDataMappingConfiguration>(_configuration.GetSection("FssDataMappingConfiguration"));
             services.Configure<ScsDataMappingConfiguration>(_configuration.GetSection("ScsDataMappingConfiguration"));
             services.Configure<EventProcessorConfiguration>(_configuration.GetSection("EventProcessorConfiguration"));
+            services.Configure<ElasticApmConfiguration>(_configuration.GetSection("ElasticAPM"));
 
             services.AddApplicationInsightsTelemetry();
             services.AddLogging(loggingBuilder =>
@@ -114,6 +119,11 @@ namespace UKHO.ExternalNotificationService.API
                 .AddCheck<AzureBlobStorageHealthCheck>("AzureBlobStorageHealthCheck")
                 .AddCheck<AzureMessageQueueHealthCheck>("AzureMessageQueueHealthCheck")
                 .AddCheck<AzureWebJobHealthCheck>("AzureWebJobsHealthCheck");
+
+
+            services.AddElasticSearchClient(_configuration);
+            services.AddScoped<IAddsMonitoringService, AddsElasticMonitoringService>();
+            
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Elastic.Apm" Version="1.28.0" />
     <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.28.0" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.1" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.7" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
@@ -64,10 +64,12 @@
         "ApiKey": "",
         "ServerURL": "",
         "ServiceName": "",
-        "Environment": ""
+        "Environment": "",
+        "CloudId": "",
+        "IndexName": ""
     },
-
     "EventProcessorConfiguration": {
         "ScsEventPublishDelayInSeconds": 10
-    }
+    },
+    "ADDSMonitoringEnabled": false
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/ElasticApmConfiguration.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/ElasticApmConfiguration.cs
@@ -1,0 +1,10 @@
+﻿namespace UKHO.ExternalNotificationService.Common.Configuration
+{
+    public class ElasticApmConfiguration
+    {
+        public string ApiKey { get; set; } = string.Empty;
+        public string CloudId { get; set; } = string.Empty;
+        public string IndexName { get; set; } = string.Empty;
+        public string Environment { get; set; } = string.Empty;
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Logging/EventIds.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Logging/EventIds.cs
@@ -264,6 +264,22 @@ namespace UKHO.ExternalNotificationService.Common.Logging
         /// 900065 -  File share service event data mapping configuration error.
         /// </summary>
         FSSEventDataMappingConfigurationError = 900065,
+        /// <summary>
+        /// 900066 -  Elasticsearch Client is not configured.
+        /// </summary>
+        ElasticsearchClientNotConfigured = 900066,
+        /// <summary>
+        /// 900067 -  Stop ADDS Elastic Monitoring Process Start.
+        /// </summary>
+        StopAddsElasticMonitoringProcessStart = 900067,
+        /// <summary>
+        /// 900068 -  Stop ADDS Elastic Monitoring Process completed.
+        /// </summary>
+        StopAddsElasticMonitoringProcessCompleted = 900068,
+        /// <summary>
+        /// 900069 -  Stop ADDS Elastic Monitoring Process error.
+        /// </summary>
+        StopAddsElasticMonitoringProcessError = 900069
     }
 
     public static class EventIdExtensions

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Monitoring/AddsData.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Monitoring/AddsData.cs
@@ -1,0 +1,11 @@
+﻿namespace UKHO.ExternalNotificationService.Common.Models.Monitoring
+{
+    public class AddsData
+    {
+        public string Type { get; set; } = string.Empty;
+        public string ProductName { get; set; } = string.Empty;
+        public int EditionNumber { get; set; }
+        public int UpdateNumber { get; set; }
+        public string StatusName { get; set; } = string.Empty;
+    }
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Monitoring/ElasticLogDocument.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Monitoring/ElasticLogDocument.cs
@@ -1,0 +1,23 @@
+﻿using System.Text.Json.Serialization;
+
+namespace UKHO.ExternalNotificationService.Common.Models.Monitoring;
+
+public class ElasticLogDocument
+{
+    [JsonPropertyName("@timestamp")]
+    public DateTime Timestamp { get; set; }
+    public string Id { get; set; }
+    public string ProductName { get; set; }
+    public int? EditionNumber { get; set; }
+    public int UpdateNumber { get; set; }
+    public string StatusName { get; set; }
+    public string EventType { get; set; }
+    public string TraceId { get; set; }
+    public DateTime? StartTimestamp { get; set; }
+    public DateTime? StopTimestamp { get; set; }
+    public int? Duration { get; set; }
+    public bool? ImmediateRelease { get; set; }
+    public string Environment { get; set; }
+    public bool IsAbnormal { get; set; }
+    public bool IsComplete { get; set; }
+}


### PR DESCRIPTION
**Implementation to stop ADDS monitoring once content published event is sent**

- Added `ADDSMonitoringEnabled` setting in `appsettings.json`.
- Updated `ScsEventProcessor` to use `IConfiguration` and `IAddsMonitoringService`.
- Implemented conditional ADDS monitoring logic in `ScsEventProcessor`.
- Added unit tests for ADDS monitoring in `ScsEventProcessorTest.cs`.
- Introduced `ElasticApmConfiguration` for Elastic APM settings.
- Created `AddsElasticMonitoringService` to manage ADDS monitoring.
- Defined `IAddsMonitoringService` interface.
- Added `ElasticLogDocument` for Elasticsearch log structure.
- Updated `Startup.cs` to register `AddsElasticMonitoringService` and configure Elasticsearch.
- Added unit tests for Elasticsearch client registration in `ServiceCollectionExtensionsTest.cs`.
- Added unit tests for `AddsElasticMonitoringService` in `AddsElasticMonitoringTest.cs`.
- Updated `EventIds.cs` with new event IDs for ADDS monitoring.
- Updated project file to include `Elastic.Clients.Elasticsearch` package.