### PR TITLE
Update from main 2024-09-02

### DIFF
--- a/NVDSuppressions.xml
+++ b/NVDSuppressions.xml
@@ -261,15 +261,6 @@
   <suppress>
     <notes>
       <![CDATA[
-   file name: Various
-   False positive - relates to Drupal
-   ]]>
-    </notes>
-    <cve>CVE-2014-9152</cve>
-  </suppress>
-  <suppress>
-    <notes>
-      <![CDATA[
    file name: System.Security.Cryptography.X509Certificates:4.1.0
    file name: System.Security.Cryptography.X509Certificates:4.3.0
    Applies to .NET Core 1.0, 1.1, and 2.0 only.
@@ -331,16 +322,6 @@
     </notes>
     <packageUrl regex="true">^pkg:nuget/System\.ClientModel@.*$</packageUrl>
     <cpe>cpe:/a:microsoft:services</cpe>
-    <cpe>cpe:/a:services_project:services</cpe>
-    <cve>CVE-2014-9152</cve>
-  </suppress>
-  <suppress>
-    <notes>
-      <![CDATA[
-   file name: System.Runtime.CompilerServices.Unsafe.dll
-   ]]>
-    </notes>
-    <packageUrl regex="true">^pkg:generic/System\.Runtime\.CompilerServices\.Unsafe@.*$</packageUrl>
     <cpe>cpe:/a:services_project:services</cpe>
     <cve>CVE-2014-9152</cve>
   </suppress>

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.42.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.2" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.7.3" />
   </ItemGroup>
 
 </Project>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.28.4" />
-    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.28.4" />
+    <PackageReference Include="Elastic.Apm" Version="1.28.5" />
+    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.28.5" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.1" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Elastic.Apm" Version="1.28.5" />
     <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.28.5" />
-    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.1" />
+    <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.5" />
     <PackageReference Include="FluentValidation" Version="11.9.2" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
@@ -13,7 +13,7 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.0" />
-    <PackageReference Include="NUnit" Version="4.2.1" />
+    <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
@@ -10,8 +10,8 @@
     <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.19.1" />
-    <PackageReference Include="Elastic.Apm" Version="1.28.4" />
-    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.28.4" />
+    <PackageReference Include="Elastic.Apm" Version="1.28.5" />
+    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.28.5" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.1" />


### PR DESCRIPTION
#### PR Classification
Code cleanup and dependency updates.

#### PR Summary
This pull request removes outdated CVE suppressions and updates various package references to newer versions.
- `NVDSuppressions.xml`: Removed suppressions for `CVE-2014-9152` and `CVE-2015-0897`.
- `UKHO.D365CallbackDistributorStub.API.Tests.csproj`, `UKHO.ExternalNotificationService.API.FunctionalTests.csproj`, `UKHO.ExternalNotificationService.API.UnitTests.csproj`, `UKHO.ExternalNotificationService.Common.UnitTests.csproj`, `UKHO.ExternalNotificationService.Webjob.UnitTests.csproj`: Updated `NUnit` package from `4.2.1` to `4.2.2`.
- `UKHO.D365CallbackDistributorStub.API.csproj`: Updated `Swashbuckle.AspNetCore` package from `6.7.2` to `6.7.3`.
- `UKHO.ExternalNotificationService.API.csproj`: Updated `Elastic.Apm`, `Elastic.Apm.AspNetCore`, and `Elastic.Clients.Elasticsearch` packages to newer versions.
- `UKHO.ExternalNotificationService.SubscriptionService.csproj`: Updated `Elastic.Apm` and `Elastic.Apm.Azure.Storage` packages from `1.28.4` to `1.28.5`.
