### PR TITLE
Abzu-169456- Add new Elastic APM env vars to azure-pipelines.yml

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -390,6 +390,10 @@ stages:
             value: $(elasticAPM-ServiceName)
           - name: "ElasticAPM.WebJobServiceName"
             value: $(elasticAPM-WebJobServiceName)
+          - name: "ElasticAPM.CloudId"
+            value: $(elasticAPM-CloudId)
+          - name: "ElasticAPM.IndexName"
+            value: $(elasticAPM-IndexName)
         strategy:
           runOnce:
             deploy:
@@ -485,6 +489,10 @@ stages:
             value: $(elasticAPM-ServiceName)
           - name: "ElasticAPM.WebJobServiceName"
             value: $(elasticAPM-WebJobServiceName)
+          - name: "ElasticAPM.CloudId"
+            value: $(elasticAPM-CloudId)
+          - name: "ElasticAPM.IndexName"
+            value: $(elasticAPM-IndexName)
         strategy:
           runOnce:
             deploy:
@@ -566,6 +574,10 @@ stages:
             value: $(elasticAPM-ServiceName)
           - name: "ElasticAPM.WebJobServiceName"
             value: $(elasticAPM-WebJobServiceName)
+          - name: "ElasticAPM.CloudId"
+            value: $(elasticAPM-CloudId)
+          - name: "ElasticAPM.IndexName"
+            value: $(elasticAPM-IndexName)
         strategy:
           runOnce:
             deploy:
@@ -647,6 +659,10 @@ stages:
             value: $(elasticAPM-ServiceName)
           - name: "ElasticAPM.WebJobServiceName"
             value: $(elasticAPM-WebJobServiceName)
+          - name: "ElasticAPM.CloudId"
+            value: $(elasticAPM-CloudId)
+          - name: "ElasticAPM.IndexName"
+            value: $(elasticAPM-IndexName)
         strategy:
           runOnce:
             deploy:
@@ -800,6 +816,10 @@ stages:
             value: $(elasticAPM-ServiceName)
           - name: "ElasticAPM.WebJobServiceName"
             value: $(elasticAPM-WebJobServiceName)
+          - name: "ElasticAPM.CloudId"
+            value: $(elasticAPM-CloudId)
+          - name: "ElasticAPM.IndexName"
+            value: $(elasticAPM-IndexName)
         strategy:
           runOnce:
             deploy:


### PR DESCRIPTION
Added ElasticAPM.CloudId and ElasticAPM.IndexName variables to azure-pipelines.yml. These are included alongside existing ElasticAPM variables (ServiceName, WebJobServiceName, ServerURL). Changes are applied to multiple sections/stages in the pipeline.