### PR TITLE
Abzu-179289-Improve logging and update CustomCloudEvent properties

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Controllers/WebhookController.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Controllers/WebhookController.cs
@@ -53,7 +53,7 @@ namespace UKHO.ExternalNotificationService.API.Controllers
             string jsonContent = await reader.ReadToEndAsync();
             CustomCloudEvent? customCloudEvent = JsonSerializer.Deserialize<CustomCloudEvent>(jsonContent, JOptions);
 
-            _logger.LogInformation(EventIds.ENSWebhookRequestStart.ToEventId(), "External notification service webhook request started for event:{eventGridEvent} and _X-Correlation-ID:{correlationId}.", customCloudEvent, GetCurrentCorrelationId());
+            _logger.LogInformation(EventIds.ENSWebhookRequestStart.ToEventId(), "External notification service webhook request started for event:{eventGridEvent} and _X-Correlation-ID:{correlationId}.", JsonSerializer.Serialize(customCloudEvent), GetCurrentCorrelationId());
 
             if (customCloudEvent?.Type != null)
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Request/CustomCloudEvent.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Models/Request/CustomCloudEvent.cs
@@ -7,19 +7,19 @@ namespace UKHO.ExternalNotificationService.Common.Models.Request
     public class CustomCloudEvent
     {
         [JsonPropertyName(name: "id")]
-        public string Id { get; set; } = string.Empty;
+        public string? Id { get; set; } 
         [JsonPropertyName(name: "type")]
-        public string Type { get; set; } = string.Empty;
+        public string? Type { get; set; }
         [JsonPropertyName(name: "time")]
-        public string Time { get; set; } = string.Empty;
+        public string? Time { get; set; } 
         [JsonPropertyName(name: "dataContentType")]
-        public string DataContentType { get; set; } = string.Empty;
+        public string? DataContentType { get; set; } 
         [JsonPropertyName(name: "dataSchema")]
-        public string DataSchema { get; set; } = string.Empty;
+        public string? DataSchema { get; set; } 
         [JsonPropertyName(name: "subject")]
-        public string Subject { get; set; } = string.Empty;
+        public string? Subject { get; set; } 
         [JsonPropertyName(name: "source")]
-        public string Source { get; set; } = string.Empty;
+        public string? Source { get; set; } 
         [JsonPropertyName(name: "data")]
         public object? Data { get; set; }
     }


### PR DESCRIPTION
- Serialize `customCloudEvent` to JSON string in `WebhookController.cs` for better logging clarity.
- Change `CustomCloudEvent` properties to nullable strings to handle missing values in JSON payloads.