### PR TITLE
Update Terraform

### DIFF
--- a/Deployment/src/APIM/azure.tf
+++ b/Deployment/src/APIM/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.89.0"
+      version = "=3.116.0"
     }
   }
 
-  required_version = "=1.7.2"
+  required_version = "=1.9.6"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.apim.tfplan"

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.89.0"
+      version = "=3.116.0"
     }
   }
 
-  required_version = "=1.7.2"
+  required_version = "=1.9.6"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.deployment.tfplan"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ variables:
   - name: UKHOAssemblyCopyright
     value: "Copyright © UK Hydrographic Office"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.7.2"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: WindowPool


### PR DESCRIPTION
#### PR Classification
Version upgrades for Terraform and Azure provider.

#### PR Summary
Updated Terraform and Azure provider versions, and modified backend keys.
- `azure.tf`: Updated `azurerm` provider to `3.116.0`, Terraform version to `1.9.6`, and modified backend keys.
- `azure-pipelines.yml`: Updated Docker container version for Terraform and Azure PowerShell to `1.9.6`.
