### PR TITLE
Update from main

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/UKHO.D365CallbackDistributorStub.API"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]
@@ -14,7 +14,7 @@ updates:
   - package-ecosystem: "nuget"
     directory: "/UKHO.ExternalNotificationService.API"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     ignore:
       - dependency-name: "*"
         update-types: ["version-update:semver-major"]

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
@@ -7,9 +7,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.43.0" />
+    <PackageReference Include="Azure.Core" Version="1.44.1" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.8.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.9.0" />
   </ItemGroup>
 
 </Project>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -19,19 +19,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.20.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.8" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="NUnit" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -8,20 +8,20 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.29.0" />
-    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.29.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageReference Include="Elastic.Apm" Version="1.30.0" />
+    <PackageReference Include="Elastic.Apm.AspNetCore" Version="1.30.0" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="8.15.5" />
     <PackageReference Include="FluentValidation" Version="11.10.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.8" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.8" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.10" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.10" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.65.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.26.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.27.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.11.5" />
     <PackageReference Include="Azure.ResourceManager.EventGrid" Version="1.0.1" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.20.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.1" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.22.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.10" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
     <PackageReference Include="WindowsAzure.Storage" Version="9.3.3" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
@@ -7,28 +7,28 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.3.2" />
-    <PackageReference Include="Azure.Identity" Version="1.12.1" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.6.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.20.0" />
-    <PackageReference Include="Elastic.Apm" Version="1.29.0" />
-    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.29.0" />
+    <PackageReference Include="Azure.Identity" Version="1.13.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.20.1" />
+    <PackageReference Include="Elastic.Apm" Version="1.30.0" />
+    <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.30.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Azure.WebJobs" Version="3.0.41" />
-    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.2" />
+    <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.3" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.0.1" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="8.0.1" />
     <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
     <PackageReference Include="Serilog" Version="3.1.1" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-    <PackageReference Include="System.Text.Json" Version="8.0.4" />
+    <PackageReference Include="System.Text.Json" Version="8.0.5" />
     <PackageReference Include="UKHO.Torus.Core" Version="2.0.0" />
     <PackageReference Include="UKHO.Torus.Enc.Core" Version="2.0.1" />
   </ItemGroup>


### PR DESCRIPTION
#### PR Classification
Dependency updates to improve security and maintainability.

#### PR Summary
Updated dependency versions and adjusted update schedules for NuGet packages.
- `dependabot.yml`: Changed NuGet update schedule from "weekly" to "monthly".
- `UKHO.D365CallbackDistributorStub.API.csproj`: Updated `Azure.Core` to `1.44.1` and `Swashbuckle.AspNetCore` to `6.9.0`.
- `UKHO.ExternalNotificationService.API.FunctionalTests.csproj`: Updated multiple packages including `Azure.Identity` to `1.13.0` and `System.Text.Json` to `8.0.5`.
- `UKHO.ExternalNotificationService.API.csproj`: Updated multiple packages including `Azure.Identity` to `1.13.0` and `Elastic.Apm` to `1.30.0`.
- `UKHO.ExternalNotificationService.SubscriptionService.csproj`: Updated multiple packages including `Azure.Identity` to `1.13.0` and `Microsoft.Extensions.Hosting` to `8.0.1`.
