### PR TITLE
Terraform - deprecated resources

### DIFF
--- a/Deployment/src/Modules/AzureDashboard/main.tf
+++ b/Deployment/src/Modules/AzureDashboard/main.tf
@@ -1,13 +1,13 @@
 data "azurerm_subscription" "current" {
 }
-#Deprecated Resource and will be removed in V4 replacement azurerm_portal_dashboard
-resource "azurerm_dashboard" "azure-dashboard" {
-  name                = var.name
-  resource_group_name = var.resource_group.name
-  location            = var.resource_group.location
-  tags                = var.tags
+
+resource "azurerm_portal_dashboard" "azure-dashboard" {
+  name                 = var.name
+  resource_group_name  = var.resource_group.name
+  location             = var.resource_group.location
+  tags                 = var.tags
   dashboard_properties = templatefile("${path.module}/dashboard.tpl", {
     subscription_id = data.azurerm_subscription.current.subscription_id,
-    environment = var.environment
+    environment     = var.environment
   })
 }

--- a/Deployment/src/Modules/Webapp/outputs.tf
+++ b/Deployment/src/Modules/Webapp/outputs.tf
@@ -1,41 +1,41 @@
 output "web_app_object_id" {
-  value = azurerm_app_service.webapp_service.identity.0.principal_id
+  value = azurerm_windows_web_app.webapp_service.identity.0.principal_id
 }
 
 output "web_app_tenant_id" {
-  value = azurerm_app_service.webapp_service.identity.0.tenant_id
+  value = azurerm_windows_web_app.webapp_service.identity.0.tenant_id
 }
 
 output "default_site_hostname" {
-  value = azurerm_app_service.webapp_service.default_site_hostname
+  value = azurerm_windows_web_app.webapp_service.default_hostname
 }
 
 output "webapp_scm_credentials"{
   value = merge({
-    "${var.name}-scm-username" =  azurerm_app_service.webapp_service.site_credential[0].username 
+    "${var.name}-scm-username" =  azurerm_windows_web_app.webapp_service.site_credential[0].name 
     },
     {
-    "${var.name}-scm-password" =  azurerm_app_service.webapp_service.site_credential[0].password 
+    "${var.name}-scm-password" =  azurerm_windows_web_app.webapp_service.site_credential[0].password 
     })
   sensitive = true
 }
 
 output "webapp_name" {
-  value = var.env_name == "live" ? null : azurerm_app_service.stub_webapp_service[0].name
+  value = var.env_name == "live" ? null : azurerm_windows_web_app.stub_webapp_service[0].name
 }
 
 output "default_site_hostname_ens_stub" {
-  value = var.env_name == "live" ?  null : azurerm_app_service.stub_webapp_service[0].default_site_hostname
+  value = var.env_name == "live" ?  null : azurerm_windows_web_app.stub_webapp_service[0].default_hostname
 }
 
 output "slot_principal_id" {
-  value = azurerm_app_service_slot.staging.identity.0.principal_id
+  value = azurerm_windows_web_app_slot.staging.identity.0.principal_id
 }
 
 output "slot_name" {
-  value = azurerm_app_service_slot.staging.name
+  value = azurerm_windows_web_app_slot.staging.name
 }
 
 output "slot_default_site_hostname" {
-  value = azurerm_app_service_slot.staging.default_site_hostname
+  value = azurerm_windows_web_app_slot.staging.default_hostname
 }

--- a/Deployment/src/Modules/Webapp/variables.tf
+++ b/Deployment/src/Modules/Webapp/variables.tf
@@ -42,3 +42,7 @@ variable "agent_id" {
 variable "env_name" {
   type = string
 }
+
+variable "deploy_stub" {
+  type = bool
+}

--- a/Deployment/src/main.tf
+++ b/Deployment/src/main.tf
@@ -47,6 +47,7 @@ module "webapp_service" {
   subnet_id                 = data.azurerm_subnet.main_subnet.id
   agent_id                  = data.azurerm_subnet.agent_subnet.id
   env_name                  = local.env_name
+  deploy_stub               = local.deploy_stub
   location                  = azurerm_resource_group.rg.location
   app_service_sku           = var.app_service_sku[local.env_name]
   app_settings = {

--- a/Deployment/src/migration.tf
+++ b/Deployment/src/migration.tf
@@ -1,0 +1,97 @@
+# Used to migrate deprecated resources without having to destroy and recreate them.
+# This file can be removed once the migration is complete in all environments, but will do no harm if left.
+# See PBI #145964.
+
+# service plan
+removed {
+  from = module.webapp_service.azurerm_app_service_plan.app_service_plan
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = module.webapp_service.azurerm_service_plan.app_service_plan
+  id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Web/serverFarms/${local.web_app_name}-asp"
+}
+
+# webapp
+removed {
+  from = module.webapp_service.azurerm_app_service.webapp_service
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = module.webapp_service.azurerm_windows_web_app.webapp_service
+  id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Web/sites/${local.web_app_name}"
+}
+
+# staging
+removed {
+  from = module.webapp_service.azurerm_app_service_slot.staging
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = module.webapp_service.azurerm_windows_web_app_slot.staging
+  id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Web/sites/${local.web_app_name}/slots/staging"
+}
+
+# stub (non-live only)
+removed {
+  from = module.webapp_service.azurerm_app_service.stub_webapp_service
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+locals {
+  stubs = (
+    local.deploy_stub ? [0] : []
+  )
+}
+
+import {
+  for_each = local.stubs
+  to    = module.webapp_service.azurerm_windows_web_app.stub_webapp_service[each.key]
+  id    = "${azurerm_resource_group.rg.id}/providers/Microsoft.Web/sites/${local.web_app_name}-stub"
+}
+
+# swift
+removed {
+  from = module.webapp_service.azurerm_app_service_virtual_network_swift_connection.webapp_vnet_integration
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+removed {
+  from = module.webapp_service.azurerm_app_service_slot_virtual_network_swift_connection.slot_vnet_integration
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+# dashboard
+removed {
+  from = module.azure-dashboard.azurerm_dashboard.azure-dashboard
+
+  lifecycle {
+    destroy = false
+  }
+}
+
+import {
+  to = module.azure-dashboard.azurerm_portal_dashboard.azure-dashboard
+  id = "${azurerm_resource_group.rg.id}/providers/Microsoft.Portal/dashboards/ENS-${local.env_name}-monitoring-dashboard"
+}

--- a/Deployment/src/variables.tf
+++ b/Deployment/src/variables.tf
@@ -10,6 +10,7 @@ variable "resource_group_name" {
 
 locals {
   env_name           = lower(terraform.workspace)
+  deploy_stub        = local.env_name != "live"
   service_name       = "ens"
   web_app_name       = "${local.service_name}-${local.env_name}-webapp"
   key_vault_name     = "${local.service_name}-ukho-${local.env_name}-kv"

--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -48,15 +48,6 @@ steps:
       xmlTransformationRules:
       jsonTargetFiles: '**/appsettings.json'
 
-  - task: AzureCLI@2
-    displayName: "Staging slot sticky appsettings"
-    inputs:
-      azureSubscription: "${{ parameters.AzureSubscription }}"
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript: |
-        az webapp config appsettings set --resource-group $(ResourceGroup) --name $(WEB_APP_NAME) --slot $(WEB_APP_SLOT_NAME) --slot-settings WEBJOBS_STOPPED=1
-
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: Staging slot"
     inputs:

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.sln
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.sln
@@ -26,7 +26,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Pipeline", "Pipeline", "{E8
 		..\azure-pipelines.yml = ..\azure-pipelines.yml
 		..\BuildNuget.config = ..\BuildNuget.config
 		..\external-notification-service.openApi.yaml = ..\external-notification-service.openApi.yaml
-		..\global.json = ..\global.json
 		..\NVDSuppressions.xml = ..\NVDSuppressions.xml
 	EndProjectSection
 EndProject
@@ -45,6 +44,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{54CC8841-B26
 	ProjectSection(SolutionItems) = preProject
 		..\Deployment\src\azure.tf = ..\Deployment\src\azure.tf
 		..\Deployment\src\main.tf = ..\Deployment\src\main.tf
+		..\Deployment\src\migration.tf = ..\Deployment\src\migration.tf
 		..\Deployment\src\outputs.tf = ..\Deployment\src\outputs.tf
 		..\Deployment\src\resource-group.tf = ..\Deployment\src\resource-group.tf
 		..\Deployment\src\variables.tf = ..\Deployment\src\variables.tf

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -638,7 +638,6 @@ stages:
             scriptPath: '$(Pipeline.Workspace)/terraformartifact/set_stub_url.ps1'
             arguments: '-d365uri $(D365EnvApiUri) -resourceGroup $(ResourceGroup) -webappName $(WEB_APP_NAME)'
 
-            
   - stage: Livedeploy
     dependsOn:
       - QADeploy


### PR DESCRIPTION
#### PR Classification
Deprecation and resource migration.

#### PR Summary
This pull request deprecates and replaces several Azure resources, adds a new variable, and updates outputs and deployment configurations.
- `azurerm_subscription` data source removed; `azurerm_dashboard` replaced with `azurerm_portal_dashboard`.
- `azurerm_app_service_plan` replaced with `azurerm_service_plan`; `azurerm_app_service` replaced with `azurerm_windows_web_app`.
- New `migration.tf` file added to handle resource migration without destruction.
- `continuous-deployment.yml` updated to remove a task for staging slot settings.
- `UKHO.ExternalNotificationService.API.sln` updated to include `migration.tf` and remove `global.json`.
