### PR TITLE
Update Elastic APM configuration to use AddsApiKey

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Extensions/ServiceCollectionExtensionsTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Extensions/ServiceCollectionExtensionsTest.cs
@@ -19,7 +19,7 @@ public class ServiceCollectionExtensionsTest
         _inMemorySettings = new()
         {
             {"ElasticApm:CloudId", cloudId},
-            {"ElasticApm:ApiKey", "test-api-key"},
+            {"ElasticApm:ADDSApiKey", "test-api-key"},
             {"ADDSMonitoringEnabled", "true"}
         };
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Extensions/ServiceCollectionExtensions.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/Extensions/ServiceCollectionExtensions.cs
@@ -17,7 +17,7 @@ public static class ServiceCollectionExtensions
             () ?? new ElasticApmConfiguration();
 
         ElasticsearchClientSettings settings = new(elasticApmConfiguration.CloudId,
-            new ApiKey(elasticApmConfiguration.ApiKey));
+            new ApiKey(elasticApmConfiguration.AddsApiKey));
 
         services.AddSingleton(new ElasticsearchClient(settings));
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
@@ -66,7 +66,8 @@
         "ServiceName": "",
         "Environment": "",
         "CloudId": "",
-        "IndexName": ""
+        "IndexName": "",
+        "ADDSApiKey": ""
     },
     "EventProcessorConfiguration": {
         "ScsEventPublishDelayInSeconds": 10

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/ElasticApmConfiguration.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/ElasticApmConfiguration.cs
@@ -6,5 +6,6 @@
         public string CloudId { get; set; } = string.Empty;
         public string IndexName { get; set; } = string.Empty;
         public string Environment { get; set; } = string.Empty;
+        public string AddsApiKey { get; set; } = string.Empty;
     }
 }

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -377,6 +377,8 @@ stages:
             value: $(elasticAPM-CloudId)
           - name: "ElasticAPM.IndexName"
             value: $(elasticAPM-IndexName)
+          - name: "ElasticAPM.ADDSApiKey"
+            value: $(elasticAPM-ADDSApiKey)
         strategy:
           runOnce:
             deploy:
@@ -449,6 +451,8 @@ stages:
             value: $(elasticAPM-CloudId)
           - name: "ElasticAPM.IndexName"
             value: $(elasticAPM-IndexName)
+          - name: "ElasticAPM.ADDSApiKey"
+            value: $(elasticAPM-ADDSApiKey)
         strategy:
           runOnce:
             deploy:
@@ -507,6 +511,8 @@ stages:
             value: $(elasticAPM-CloudId)
           - name: "ElasticAPM.IndexName"
             value: $(elasticAPM-IndexName)
+          - name: "ElasticAPM.ADDSApiKey"
+            value: $(elasticAPM-ADDSApiKey)
         strategy:
           runOnce:
             deploy:
@@ -565,6 +571,8 @@ stages:
             value: $(elasticAPM-CloudId)
           - name: "ElasticAPM.IndexName"
             value: $(elasticAPM-IndexName)
+          - name: "ElasticAPM.ADDSApiKey"
+            value: $(elasticAPM-ADDSApiKey)
         strategy:
           runOnce:
             deploy:
@@ -694,6 +702,8 @@ stages:
             value: $(elasticAPM-CloudId)
           - name: "ElasticAPM.IndexName"
             value: $(elasticAPM-IndexName)
+          - name: "ElasticAPM.ADDSApiKey"
+            value: $(elasticAPM-ADDSApiKey)
         strategy:
           runOnce:
             deploy:


### PR DESCRIPTION
Update Elastic APM configuration to use AddsApiKey

Replaced ElasticApm:ApiKey with ElasticApm:ADDSApiKey in
ServiceCollectionExtensionsTest.cs. Updated
ServiceCollectionExtensions.cs to use AddsApiKey from
ElasticApmConfiguration. Added ADDSApiKey entry to
appsettings.json. Extended ElasticApmConfiguration with
AddsApiKey property. Updated azure-pipelines.yml to include
ElasticAPM.AddsApiKey variable for deployment.