### PR TITLE
Replace xmlTransformationRules with enableXmlTransform

### DIFF
--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -10,7 +10,7 @@ steps:
     displayName: "File Transform: Ens Config" #Replace ens instance value from pipeline 
     inputs:
       folderPath: '$(Pipeline.Workspace)/terraformartifact/src'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: 'appsettings.json'
 
   - task: PowerShell@2
@@ -45,7 +45,7 @@ steps:
     displayName: "File Transform: WebAppSettings"
     inputs:
       folderPath: '$(Pipeline.Workspace)/ExternalNotificationService/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: AzureWebApp@1
@@ -87,7 +87,7 @@ steps:
     condition: and(succeeded(), ne(variables['Environment.Name'], 'Ens-Live'))
     inputs:
       folderPath: '$(Pipeline.Workspace)/StubWebAPI/*.zip'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'           
 
   - task: AzureWebApp@1

--- a/Deployment/templates/functional-test-process.yml
+++ b/Deployment/templates/functional-test-process.yml
@@ -15,7 +15,7 @@ steps:
     displayName: "File Transform: functionaltests"
     inputs:
       folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-      xmlTransformationRules:
+      enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
   - task: UseDotNet@2

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -579,7 +579,7 @@ stages:
                   displayName: "File Transform: functionaltests"
                   inputs:
                     folderPath: '$(Build.SourcesDirectory)/functionaltests/'
-                    xmlTransformationRules:
+                    enableXmlTransform: false
                     jsonTargetFiles: '**/appsettings.json'
 
                 - task: UseDotNet@2


### PR DESCRIPTION
Modified `FileTransform@2` tasks in `continuous-deployment.yml`, `functional-test-process.yml`, and `azure-pipelines.yml` files. Removed `xmlTransformationRules` parameter and set `enableXmlTransform` to `false`, disabling XML transformation.