### PR TITLE
Remove Torus package references from csproj

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
@@ -29,8 +29,6 @@
     <PackageReference Include="Serilog.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="System.Text.Json" Version="8.0.5" />
-    <PackageReference Include="UKHO.Torus.Core" Version="2.0.0" />
-    <PackageReference Include="UKHO.Torus.Enc.Core" Version="2.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
#### PR Classification
Code cleanup to remove unused package references.

#### PR Summary
Removed unnecessary package references from the project file to streamline dependencies.
- `UKHO.ExternalNotificationService.SubscriptionService.csproj`: Removed `UKHO.Torus.Core` package (version 2.0.0) and `UKHO.Torus.Enc.Core` package (version 2.0.1).
