### PR TITLE
Use template for dependency checker

### DIFF
--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -37,9 +37,9 @@ jobs:
 
   - template: dependency-checker/windows-dependency-checker.yaml@UKHOTemplates
     parameters:
-      scanName: "External-Notification-Service - $(Build.SourceBranchName)"
-      scanPath: "$(Build.SourcesDirectory)\\UKHO.ExternalNotificationService.API"
-      suppressionPath: "$(Build.SourcesDirectory)\\NVDSuppressions.xml"
+      scanName: 'External-Notification-Service - $(Build.SourceBranchName)'
+      scanPath: '$(Build.SourcesDirectory)\UKHO.ExternalNotificationService.API'
+      suppressionPath: '$(Build.SourcesDirectory)\NVDSuppressions.xml'
 
 - job: UnitTestsAndCodeCoverage
   workspace:

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -21,6 +21,7 @@ jobs:
       packageType: sdk
       version: '${{ parameters.DotNetVersion }}'
       workingDirectory: '$(Build.SourcesDirectory)'
+
   - task: DotNetCoreCLI@2
     displayName: ".Net Core - NuGet restore non test projects only"
     inputs:
@@ -34,26 +35,11 @@ jobs:
       workingDirectory: '$(Build.SourcesDirectory)\UKHO.ExternalNotificationService.API'
       packagesDirectory: '$(Build.SourcesDirectory)\UKHO.ExternalNotificationService.API\packages'
 
-  - task: CmdLine@1
-    displayName: "Run OWASP Dependency Checker"
-    inputs:
-      filename: 'dependency-check.bat'
-      arguments: '--project "External-Notification-Service - $(Build.SourceBranchName)" --scan "$(Build.SourcesDirectory)\UKHO.ExternalNotificationService.API" --out "$(Build.ArtifactStagingDirectory)\DCReport" --suppression $(Build.SourcesDirectory)\NVDSuppressions.xml --noupdate'
-  
-  - task: PublishBuildArtifacts@1
-    displayName: "Publish Artifact: OWASP Dependency Checker Report"
-    inputs:
-      PathtoPublish: '$(Build.ArtifactStagingDirectory)\DCReport'
-      ArtifactName: "OWASP Dependency Checker Report"
-
-  - task: PowerShell@1
-    displayName: "Fail Build if Dependency Check Finds Any Vulnerabilities"
-    inputs:
-      scriptType: inlineScript
-      arguments: '-ReportLocation $(Build.ArtifactStagingDirectory)\DCReport\*'
-      inlineScript: |
-        param($ReportLocation)
-        Invoke-VulnerabilityCheck -ReportLocation $ReportLocation
+  - template: dependency-checker/windows-dependency-checker.yaml@UKHOTemplates
+    parameters:
+      scanName: "External-Notification-Service - $(Build.SourceBranchName)"
+      scanPath: "$(Build.SourcesDirectory)\\UKHO.ExternalNotificationService.API"
+      suppressionPath: "$(Build.SourcesDirectory)\\NVDSuppressions.xml"
 
 - job: UnitTestsAndCodeCoverage
   workspace:


### PR DESCRIPTION
#### PR Classification
Build pipeline configuration update for a .NET project.

#### PR Summary
Updated the build pipeline to streamline dependency checking.
- Removed OWASP Dependency Checker steps and introduced a new template `dependency-checker/windows-dependency-checker.yaml@UKHOTemplates` for dependency checking.
