### PR TITLE
Update test packages

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -32,7 +32,7 @@ dotnet_style_prefer_inferred_tuple_names = true:suggestion
 dotnet_style_prefer_inferred_anonymous_type_member_names = true:suggestion
 dotnet_style_prefer_compound_assignment = true:suggestion
 dotnet_style_prefer_simplified_interpolation = true:suggestion
-dotnet_style_prefer_collection_expression = when_types_loosely_match:suggestion
+dotnet_style_prefer_collection_expression = when_types_exactly_match:suggestion
 dotnet_style_namespace_match_folder = true:suggestion
 dotnet_style_readonly_field = true:suggestion
 
@@ -186,6 +186,7 @@ csharp_prefer_system_threading_lock = true:suggestion
 csharp_style_prefer_null_check_over_type_check = true:suggestion
 csharp_style_prefer_local_over_anonymous_function = true:suggestion
 csharp_style_implicit_object_creation_when_type_is_apparent = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
 
 # C++ Files
 [*.{cpp,h,in}]

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/Services/Queues/ExpirationListTests.cs
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/Services/Queues/ExpirationListTests.cs
@@ -1,11 +1,8 @@
-﻿
-using NUnit.Framework;
-using NUnit.Framework.Legacy;
+﻿using NUnit.Framework;
 using UKHO.D365CallbackDistributorStub.API.Services.Data;
 
 namespace UKHO.D365CallbackDistributorStub.API.Tests.Services.Queues
 {
-
     public class ExpirationListTests
     {
         [Test]
@@ -35,9 +32,9 @@ namespace UKHO.D365CallbackDistributorStub.API.Tests.Services.Queues
             expirationList.Add(message1);
             expirationList.Add(message2);
 
-            CollectionAssert.Contains(expirationList, message0);
-            CollectionAssert.Contains(expirationList, message1);
-            CollectionAssert.Contains(expirationList, message2);
+            Assert.That(expirationList, Has.Member(message0));
+            Assert.That(expirationList, Has.Member(message1));
+            Assert.That(expirationList, Has.Member(message2));
         }
 
         [Test]
@@ -55,7 +52,7 @@ namespace UKHO.D365CallbackDistributorStub.API.Tests.Services.Queues
 
             Thread.Sleep(TimeSpan.FromSeconds(3));
 
-            CollectionAssert.IsEmpty(expirationList);
+            Assert.That(expirationList, Is.Empty);
         }
 
         [Test]
@@ -73,9 +70,9 @@ namespace UKHO.D365CallbackDistributorStub.API.Tests.Services.Queues
 
             expirationList.Remove(message1);
 
-            CollectionAssert.Contains(expirationList, message0);
-            CollectionAssert.DoesNotContain(expirationList, message1);
-            CollectionAssert.Contains(expirationList, message2);
+            Assert.That(expirationList, Has.Member(message0));
+            Assert.That(expirationList, Has.No.Member(message1));
+            Assert.That(expirationList, Has.Member(message2));
         }
     }
 }

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/Services/Queues/Message.cs
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/Services/Queues/Message.cs
@@ -1,15 +1,7 @@
 ﻿namespace UKHO.D365CallbackDistributorStub.API.Tests.Services.Queues
 {
-
-    public class Message
+    public class Message(string data)
     {
-        private readonly string _data;
-
-        public Message(string data)
-        {
-            _data = data;
-        }
-
-        public string Data => _data;
+        public string Data { get; } = data;
     }
 }

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
@@ -13,7 +13,11 @@
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -30,9 +31,9 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             TestConfig = new TestConfiguration();
             EnsApiClient = new EnsApiClient(TestConfig.EnsApiBaseUrl);
 
-            var filePathFssAvcs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
-            var filePathFssMsi = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssMsiPayloadFileName);
-            var filePathScs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsPayloadFileName);
+            string filePathFssAvcs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            string filePathFssMsi = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssMsiPayloadFileName);
+            string filePathScs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsPayloadFileName);
 
             D365FssAvcsPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssAvcs), JOptions);
             D365FssMsiPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssMsi), JOptions);
@@ -48,46 +49,46 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365PayloadWithoutAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365PayloadWithInvalidAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            var invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, invalidToken);
+            string invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, invalidToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssAvcsPayload_ThenAcceptedStatusIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssMsiPayload_ThenAcceptedStatusIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssMsiPayload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssMsiPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365ScsPayload_ThenAcceptedStatusIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365ScsPayload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365ScsPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithEmptyD365Payload_ThenABadRequestStatusIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(null, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(null, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
             Assert.Multiple(() =>
             {
@@ -101,10 +102,10 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         {
             D365FssAvcsPayload.InputParameters = null;
 
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
             Assert.Multiple(() =>
             {
@@ -118,10 +119,10 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         {
             D365FssAvcsPayload.PostEntityImages = null;
 
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
             Assert.Multiple(() =>
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -9,7 +8,8 @@ using UKHO.ExternalNotificationService.API.FunctionalTests.Model;
 
 namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 {
-    class D365HttpPayloadValidationTest
+    [TestFixture]
+    public class D365HttpPayloadValidationTest
     {
         private EnsApiClient EnsApiClient { get; set; }
         private TestConfiguration TestConfig { get; set; }
@@ -30,9 +30,9 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             TestConfig = new TestConfiguration();
             EnsApiClient = new EnsApiClient(TestConfig.EnsApiBaseUrl);
 
-            string filePathFssAvcs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
-            string filePathFssMsi = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssMsiPayloadFileName);
-            string filePathScs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsPayloadFileName);
+            var filePathFssAvcs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            var filePathFssMsi = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssMsiPayloadFileName);
+            var filePathScs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsPayloadFileName);
 
             D365FssAvcsPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssAvcs), JOptions);
             D365FssMsiPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssMsi), JOptions);
@@ -48,49 +48,52 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365PayloadWithoutAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload);
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 401.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365PayloadWithInvalidAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            string invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, invalidToken);
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 401.");
+            var invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, invalidToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssAvcsPayload_ThenAcceptedStatusIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssMsiPayload_ThenAcceptedStatusIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssMsiPayload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssMsiPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365ScsPayload_ThenAcceptedStatusIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365ScsPayload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365ScsPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithEmptyD365Payload_ThenABadRequestStatusIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(null, EnsToken);
-            Assert.That(400, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 400.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(null, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
-            Assert.That(errorMessage.Errors.Any(e => e.Source == "requestBody"));
-            Assert.That(errorMessage.Errors.Any(e => e.Description == "Either body is null or malformed."));
+            Assert.Multiple(() =>
+            {
+                Assert.That(errorMessage.Errors.Any(e => e.Source == "requestBody"));
+                Assert.That(errorMessage.Errors.Any(e => e.Description == "Either body is null or malformed."));
+            });
         }
 
         [Test]
@@ -98,13 +101,16 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         {
             D365FssAvcsPayload.InputParameters = null;
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
-            Assert.That(400, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 400.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
-            Assert.That(errorMessage.Errors.Any(e => e.Source == "inputParameters"));
-            Assert.That(errorMessage.Errors.Any(e => e.Description == "D365Payload InputParameters cannot be blank or null."));
+            Assert.Multiple(() =>
+            {
+                Assert.That(errorMessage.Errors.Any(e => e.Source == "inputParameters"));
+                Assert.That(errorMessage.Errors.Any(e => e.Description == "D365Payload InputParameters cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -112,13 +118,16 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         {
             D365FssAvcsPayload.PostEntityImages = null;
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
-            Assert.That(400, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 400.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssAvcsPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 400.");
 
-            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
-            Assert.That(errorMessage.Errors.Any(e => e.Source == "postEntityImages"));
-            Assert.That(errorMessage.Errors.Any(e => e.Description == "D365Payload PostEntityImages cannot be blank or null."));
+            Assert.Multiple(() =>
+            {
+                Assert.That(errorMessage.Errors.Any(e => e.Source == "postEntityImages"));
+                Assert.That(errorMessage.Errors.Any(e => e.Description == "D365Payload PostEntityImages cannot be blank or null."));
+            });
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/DeleteEventGridSubscriptionToD365WebhookTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/DeleteEventGridSubscriptionToD365WebhookTest.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -11,7 +10,8 @@ using UKHO.ExternalNotificationService.API.FunctionalTests.Model;
 
 namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 {
-    class DeleteEventGridSubscriptionToD365WebhookTest
+    [TestFixture]
+    public class DeleteEventGridSubscriptionToD365WebhookTest
     {
         public object JsonSerialize { get; private set; }
         private EnsApiClient EnsApiClient { get; set; }
@@ -30,8 +30,8 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             TestConfig = new TestConfiguration();
             EnsApiClient = new EnsApiClient(TestConfig.EnsApiBaseUrl);
 
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
-            D365Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePath),JOptions);
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            D365Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePath), JOptions);
             D365Payload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
 
             ADAuthTokenProvider adAuthTokenProvider = new();
@@ -43,35 +43,37 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         public async Task WhenICallTheEnsSubscriptionApiWithStatusInActive_ThenSubscriptionHasBeenDeleted()
         {
             // Set the new subscriptionId for D365 payload
-            string subscriptionId = Guid.NewGuid().ToString();
+            var subscriptionId = Guid.NewGuid().ToString();
             D365Payload.PostEntityImages[0].Value.Attributes[0].Value = subscriptionId;
             D365Payload.InputParameters[0].Value.Attributes[10].Value = subscriptionId;
-            DateTime requestTime = DateTime.UtcNow;
+            var requestTime = DateTime.UtcNow;
             //Clear return status
-            HttpResponseMessage apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, null);
-            Assert.That(200, Is.EqualTo((int)apiStubResponse.StatusCode), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, null);
+            Assert.That((int)apiStubResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiStubResponse.StatusCode} is  returned, instead of the expected 200.");
 
             await Task.Delay(30000);
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(1000);
             }
 
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode} is  returned, instead of the expected 200.");
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
+            var callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
+            var callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            EnsCallbackResponseModel callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
-
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(TestConfig.SucceededStatusCode, Is.EqualTo(callBackResponseLatest.CallBackRequest.Ukho_lastresponse), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
-            Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails.Contains("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
-            Assert.That(callBackResponseLatest.TimeStamp <= new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_lastresponse, Is.EqualTo(TestConfig.SucceededStatusCode), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails, Does.Contain("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
+                Assert.That(callBackResponseLatest.TimeStamp, Is.LessThanOrEqualTo(new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second)), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
+            });
 
             //set the subscription state as InActive
             D365Payload.InputParameters[0].Value.FormattedValues[0].Value = "Inactive";
@@ -79,7 +81,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 
             await Task.Delay(30000);
             apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
@@ -87,26 +89,27 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             }
 
             callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode} is  returned, instead of the expected 200.");
 
             callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
-
             callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(TestConfig.SucceededStatusCode, Is.EqualTo(callBackResponseLatest.CallBackRequest.Ukho_lastresponse), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
-            Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails.Contains("Successfully removed subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
-            Assert.That(callBackResponseLatest.TimeStamp <= new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_lastresponse, Is.EqualTo(TestConfig.SucceededStatusCode), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails, Does.Contain("Successfully removed subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
+                Assert.That(callBackResponseLatest.TimeStamp, Is.LessThanOrEqualTo(new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second)), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
+            });
 
             //set the subscription state as Active
-
             D365Payload.InputParameters[0].Value.FormattedValues[0].Value = "Active";
             requestTime = DateTime.UtcNow;
 
             await Task.Delay(30000);
             apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
@@ -114,20 +117,19 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             }
 
             callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode} is  returned, instead of the expected 200.");
 
             callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
-
             callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(TestConfig.SucceededStatusCode, Is.EqualTo(callBackResponseLatest.CallBackRequest.Ukho_lastresponse), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
-            Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails.Contains("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
-            Assert.That(callBackResponseLatest.TimeStamp <= new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
-
-
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_lastresponse, Is.EqualTo(TestConfig.SucceededStatusCode), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails, Does.Contain("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
+                Assert.That(callBackResponseLatest.TimeStamp, Is.LessThanOrEqualTo(new DateTime(DateTime.UtcNow.Year, DateTime.UtcNow.Month, DateTime.UtcNow.Day, DateTime.UtcNow.Hour, DateTime.UtcNow.Minute, DateTime.UtcNow.Second)), $"Response body returned timestamp date {callBackResponseLatest.TimeStamp} , greater than the expected value.");
+            });
         }
-
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsCallBackToD365Tests.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsCallBackToD365Tests.cs
@@ -2,7 +2,6 @@
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -11,7 +10,8 @@ using UKHO.ExternalNotificationService.API.FunctionalTests.Model;
 
 namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 {
-    class EnsCallBackToD365Tests
+    [TestFixture]
+    public class EnsCallBackToD365Tests
     {
         private EnsApiClient EnsApiClient { get; set; }
         private TestConfiguration TestConfig { get; set; }
@@ -30,7 +30,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             TestConfig = new TestConfiguration();
             EnsApiClient = new EnsApiClient(TestConfig.EnsApiBaseUrl);
 
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
             D365Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePath), JOptions);
             D365Payload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
 
@@ -43,141 +43,150 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         public async Task WhenICallTheEnsSubscriptionApiWithAValidSubscriptionId_ThenSuccessStatusResponseIsReturned()
         {
             //Get the subscriptionId from D365 payload            
-            string subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
+            var subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
 
             //Clear return status
-            HttpResponseMessage apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId,null);
-            Assert.That(200, Is.EqualTo((int)apiStubResponse.StatusCode), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, null);
+            Assert.That((int)apiStubResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            DateTime requestTime = DateTime.UtcNow;
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var requestTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(1000);
             }
 
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseBody =JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
+            var callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
-            EnsCallbackResponseModel callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
+            var callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(TestConfig.SucceededStatusCode, Is.EqualTo(callBackResponseLatest.CallBackRequest.Ukho_lastresponse), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
-            Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails.Contains("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");            
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_lastresponse, Is.EqualTo(TestConfig.SucceededStatusCode), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.SucceededStatusCode}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails, Does.Contain("Successfully added subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}");
+            });
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAInValidSubscriptionId_ThenNotFoundStatusResponseIsReturned()
         {
+            var subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
 
-            string subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
+            var newSubscriptionId = subscriptionId.Remove(subscriptionId.Length - 2).Insert(subscriptionId.Length - 2, "AA");
 
-            string newSubscriptionId = subscriptionId.Remove(subscriptionId.Length - 2).Insert(subscriptionId.Length - 2, "AA");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
-
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, newSubscriptionId);
-            Assert.That(404, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
-
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, newSubscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(404), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
         }
 
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAnInvalidWebhookUrl_ThenSuccessStatusResponseIsReturnedWithFailedResponseDetails()
         {
-             D365Payload.InputParameters[0].Value.Attributes[9].Value = D365Payload.InputParameters[0].Value.Attributes[9].Value + "Failed";
+            D365Payload.InputParameters[0].Value.Attributes[9].Value = D365Payload.InputParameters[0].Value.Attributes[9].Value + "Failed";
             // Get the new subscriptionId for D365 payload
-            string subscriptionId = Guid.NewGuid().ToString();
-            D365Payload.PostEntityImages[0].Value.Attributes[0].Value = subscriptionId;            
+            var subscriptionId = Guid.NewGuid().ToString();
+            D365Payload.PostEntityImages[0].Value.Attributes[0].Value = subscriptionId;
             D365Payload.InputParameters[0].Value.Attributes[10].Value = subscriptionId;
-            DateTime requestTime = DateTime.UtcNow;           
-            
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var requestTime = DateTime.UtcNow;
+
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(1000);
             }
 
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
+            var callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
+            var callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            EnsCallbackResponseModel callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
-
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails.Contains("Failed to add subscription"),$"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}, Time : {callBackResponseLatest.TimeStamp}");
-            Assert.That(TestConfig.FailedStatusCode, Is.EqualTo(callBackResponseLatest.CallBackRequest.Ukho_lastresponse), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.FailedStatusCode}.");            
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_lastresponse, Is.EqualTo(TestConfig.FailedStatusCode), $"Invalid last response {callBackResponseLatest.CallBackRequest.Ukho_lastresponse} , Instead of expected last response {TestConfig.FailedStatusCode}.");
+                Assert.That(callBackResponseLatest.CallBackRequest.Ukho_responsedetails, Does.Contain("Failed to add subscription"), $"Last Response : {callBackResponseLatest.CallBackRequest.Ukho_responsedetails}, Time : {callBackResponseLatest.TimeStamp}");
+            });
         }
-        
-        [TestCase(400, TestName = "CallBack Stub Returns StatusCode As Bad Request")]       
+
+        [TestCase(400, TestName = "CallBack Stub Returns StatusCode As Bad Request")]
         public async Task WhenICallTheCallBackStubUrlToFailWithValidSubscriptionId_ThenValidResponseIsReturned(int statusCode)
         {
             //Get the subscriptionId from D365 payload            
-            string subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
+            var subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
 
-            HttpResponseMessage apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, statusCode);
-            Assert.That(200, Is.EqualTo((int)apiStubResponse.StatusCode), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, statusCode);
+            Assert.That((int)apiStubResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            DateTime requestTime = DateTime.UtcNow;
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);            
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var requestTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(1000);
             }
-            
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            EnsCallbackResponseModel callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
+            var callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(statusCode, Is.EqualTo(callBackResponseLatest.HttpStatusCode), $"Invalid statusCode {callBackResponseLatest.HttpStatusCode} , Instead of expected statusCode {statusCode}.");            
+            var callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
+
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.HttpStatusCode, Is.EqualTo(statusCode), $"Invalid statusCode {callBackResponseLatest.HttpStatusCode} , Instead of expected statusCode {statusCode}.");
+            });
         }
-        
+
         [TestCase(500, TestName = "CallBack Stub Returns StatusCode As Internal Server Error")]
         public async Task WhenICallTheCallBackStubUrlToFailWithValidSubscriptionId_ThenValidResponseIsReturnedWithRetryCount(int statusCode)
         {
             //Get the subscriptionId from D365 payload            
-            string subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
+            var subscriptionId = D365Payload.PostEntityImages[0].Value.Attributes[0].Value.ToString();
 
-            HttpResponseMessage apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, statusCode);
-            Assert.That(200, Is.EqualTo((int)apiStubResponse.StatusCode), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var apiStubResponse = await EnsApiClient.PostStubCommandToFailAsync(TestConfig.StubBaseUri, subscriptionId, statusCode);
+            Assert.That((int)apiStubResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiStubResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            DateTime requestTime = DateTime.UtcNow;
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);            
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
+            var requestTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode}  is  returned, instead of the expected 202.");
 
             while (DateTime.UtcNow - requestTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(1000);
             }
 
-            HttpResponseMessage callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
-            Assert.That(200, Is.EqualTo((int)callBackResponse.StatusCode), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
+            var callBackResponse = await EnsApiClient.GetEnsCallBackAsync(TestConfig.StubBaseUri, subscriptionId);
+            Assert.That((int)callBackResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {callBackResponse.StatusCode}  is  returned, instead of the expected 200.");
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
+            var callBackResponseBody = JsonSerializer.Deserialize<IEnumerable<EnsCallbackResponseModel>>(callBackResponse.Content.ReadAsStringAsync().Result, JOptions);
 
-            IEnumerable<EnsCallbackResponseModel> callBackResponseFailure = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp);
+            var callBackResponseFailure = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp);
 
             //Verify Retry Count
-            Assert.That(callBackResponseFailure.Count() > 1);
+            Assert.That(callBackResponseFailure.Count(), Is.GreaterThan(1));
 
-            EnsCallbackResponseModel callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
+            var callBackResponseLatest = callBackResponseBody.Where(x => x.TimeStamp >= requestTime).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
 
-            Assert.That(subscriptionId, Is.EqualTo(callBackResponseLatest.SubscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
-            Assert.That(statusCode, Is.EqualTo(callBackResponseLatest.HttpStatusCode), $"Invalid statusCode {callBackResponseLatest.HttpStatusCode} , Instead of expected statusCode {statusCode}.");            
-                        
-        }       
+            Assert.Multiple(() =>
+            {
+                Assert.That(callBackResponseLatest.SubscriptionId, Is.EqualTo(subscriptionId), $"Invalid subscriptionId {callBackResponseLatest.SubscriptionId} , Instead of expected subscriptionId {subscriptionId}.");
+                Assert.That(callBackResponseLatest.HttpStatusCode, Is.EqualTo(statusCode), $"Invalid statusCode {callBackResponseLatest.HttpStatusCode} , Instead of expected statusCode {statusCode}.");
+            });
+        }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
@@ -1,20 +1,18 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Tasks;
-using Azure.Messaging;
 using NUnit.Framework;
 using UKHO.ExternalNotificationService.API.FunctionalTests.Helper;
 using UKHO.ExternalNotificationService.API.FunctionalTests.Model;
 
 namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 {
-    class EnsEnterpriseEventServiceWebhookTest
+    [TestFixture]
+    public class EnsEnterpriseEventServiceWebhookTest
     {
         private EnsApiClient EnsApiClient { get; set; }
         private StubApiClient StubApiClient { get; set; }
@@ -23,8 +21,6 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         private JsonObject FssEventBody { get; set; }
         private JsonObject ScsEventBody { get; set; }
         private JsonSerializerOptions JOptions { get; set; }
-
-        
 
         [SetUp]
         public async Task SetupAsync()
@@ -45,59 +41,56 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidOptionHeaderWithoutAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync("WebHook-Request-Origin", "eventemitter.example.com");
+            var apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync("WebHook-Request-Origin", "eventemitter.example.com");
 
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
-
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidOptionHeaderWithInvalidAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            string invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
-            HttpResponseMessage apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync("WebHook-Request-Origin", "eventemitter.example.com", invalidToken);
+            var invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
+            var apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync("WebHook-Request-Origin", "eventemitter.example.com", invalidToken);
 
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
-
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidOptionHeader_ThenOkStatusIsReturnedWithResponseHeader()
         {
-            string requestHeader = "WebHook-Request-Origin";
-            string requestHeaderValue = "eventemitter.example.com";
-            HttpResponseMessage apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync(requestHeader, requestHeaderValue, EnsToken);
+            var requestHeader = "WebHook-Request-Origin";
+            var requestHeaderValue = "eventemitter.example.com";
+            var apiResponse = await EnsApiClient.OptionEnsApiSubscriptionAsync(requestHeader, requestHeaderValue, EnsToken);
 
-            Assert.That(200, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
-
-            Assert.That(apiResponse.Headers.Contains("WebHook-Allowed-Origin"));
-
-            Assert.That(requestHeaderValue, Is.EqualTo(apiResponse.Headers.GetValues("WebHook-Allowed-Origin").FirstOrDefault()));
-
+            Assert.Multiple(() =>
+            {
+                Assert.That((int)apiResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
+                Assert.That(apiResponse.Headers.Contains("WebHook-Allowed-Origin"));
+                Assert.That(requestHeaderValue, Is.EqualTo(apiResponse.Headers.GetValues("WebHook-Allowed-Origin").FirstOrDefault()));
+            });
         }
 
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidFssJObjectBodyWithoutAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            JsonObject ensWebhookJson = FssEventBody;
+            var ensWebhookJson = FssEventBody;
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson);
+            var apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson);
 
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
-
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
         }
 
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidFssJObjectBodyWithInvalidAuthToken_ThenAnUnauthorisedResponseIsReturned()
         {
-            string invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
-            JsonObject ensWebhookJson = FssEventBody;
+            var invalidToken = EnsToken.Remove(EnsToken.Length - 4).Insert(EnsToken.Length - 4, "ABAA");
+            var ensWebhookJson = FssEventBody;
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, invalidToken);
+            var apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, invalidToken);
 
-            Assert.That(401, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
-
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(401), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 401.");
         }
+
         [TestCase("AVCSData", "fss-filesPublished-AvcsData", TestName = "Valid AVCSData Business Unit event")]
         [TestCase("MaritimeSafetyInformation", "fss-filesPublished-MaritimeSafetyInformation", TestName = "Valid MaritimeSafetyInformation Business Unit event")]
         public async Task WhenICallTheEnsWebhookApiWithAValidFssJObjectBody_ThenOkStatusIsReturned(string businessUnit, string source)
@@ -105,47 +98,50 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             const string subject = "83d08093-7a67-4b3a-b431-92ba42feaea0";
             const string addHttps = "https://";
 
-            JsonObject ensWebhookJson = FssEventDataBase.GetFssEventBodyData(TestConfig, businessUnit);
+            var ensWebhookJson = FssEventDataBase.GetFssEventBodyData(TestConfig, businessUnit);
 
-            FssEventData publishDataFromFss = FssEventDataBase.GetFssEventData(TestConfig, businessUnit);
+            var publishDataFromFss = FssEventDataBase.GetFssEventData(TestConfig, businessUnit);
 
             await StubApiClient.PostStubApiCommandToReturnStatusAsync(ensWebhookJson, subject, null);
 
-            DateTime startTime = DateTime.UtcNow;
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
+            var startTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
 
             while (DateTime.UtcNow - startTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(10000);
             }
 
-            Assert.That(200, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
 
-            HttpResponseMessage stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
-            Assert.That(stubResponse.StatusCode,Is.EqualTo(HttpStatusCode.OK)); 
-            string customerJsonString = await stubResponse.Content.ReadAsStringAsync();
-            IEnumerable<DistributorRequest> deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString,JOptions);
-            DistributorRequest getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode is HttpStatusCode.OK && x.CloudEvent.Source == source)
+            var stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
+            Assert.That(stubResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+            var customerJsonString = await stubResponse.Content.ReadAsStringAsync();
+            var deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString, JOptions);
+            var getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode is HttpStatusCode.OK && x.CloudEvent.Source == source)
                 .OrderByDescending(a => a.TimeStamp)
                 .FirstOrDefault();
             Assert.That(getMatchingData, Is.Not.Null);
-            Assert.That(HttpStatusCode.OK, Is.EqualTo(getMatchingData.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(getMatchingData.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            // Validating Event Subject
-            Assert.That(subject, Is.EqualTo(getMatchingData.Subject));
-            Assert.That(getMatchingData.CloudEvent, Is.InstanceOf<CustomCloudEvent>()); 
+                // Validating Event Subject
+                Assert.That(getMatchingData.Subject, Is.EqualTo(subject));
+                Assert.That(getMatchingData.CloudEvent, Is.InstanceOf<CustomCloudEvent>());
 
-            // Validating Event Source
-            Assert.That(TestConfig.FssSources.Single(x => x.BusinessUnit == businessUnit).Source, Is.EqualTo(getMatchingData.CloudEvent.Source));
+                // Validating Event Source
+                Assert.That(getMatchingData.CloudEvent.Source, Is.EqualTo(TestConfig.FssSources.Single(x => x.BusinessUnit == businessUnit).Source));
 
-            // Validating Event Type
-            Assert.That("uk.co.admiralty.fss.filesPublished.v1", Is.EqualTo(getMatchingData.CloudEvent.Type));
-            Uri filesLinkHref = new(publishDataFromFss.Files.FirstOrDefault().Links.Get.Href);
-            string data = JsonSerializer.Serialize(getMatchingData.CloudEvent.Data);
-            FssEventData fssEventData = JsonSerializer.Deserialize<FssEventData>(data, JOptions);
+                // Validating Event Type
+                Assert.That(getMatchingData.CloudEvent.Type, Is.EqualTo("uk.co.admiralty.fss.filesPublished.v1"));
+            });
+            var filesLinkHref = new Uri(publishDataFromFss.Files.FirstOrDefault().Links.Get.Href);
+            var data = JsonSerializer.Serialize(getMatchingData.CloudEvent.Data);
+            var fssEventData = JsonSerializer.Deserialize<FssEventData>(data, JOptions);
 
             // Validating Files Link Href
-            Uri filesLinkHrefReplace = new(addHttps + TestConfig.FssPublishHostName + filesLinkHref.AbsolutePath);
+            var filesLinkHrefReplace = new Uri(addHttps + TestConfig.FssPublishHostName + filesLinkHref.AbsolutePath);
             Assert.That(filesLinkHrefReplace.ToString(), Is.Not.Null);
             Assert.That(filesLinkHrefReplace.ToString(), Is.EqualTo(fssEventData.Files.FirstOrDefault().Links.Get.Href));
 
@@ -156,8 +152,8 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             Assert.That(filesBatchStatusHrefReplace.ToString(), Is.EqualTo(fssEventData.Links.BatchStatus.Href));
 
             // Validating Files Batch Detail Href
-            Uri filesBatchDetailHref = new(publishDataFromFss.Links.BatchDetails.Href);
-            Uri filesBatchDetailHrefReplace = new(addHttps + TestConfig.FssPublishHostName + filesBatchDetailHref.AbsolutePath);
+            var filesBatchDetailHref = new Uri(publishDataFromFss.Links.BatchDetails.Href);
+            var filesBatchDetailHrefReplace = new Uri(addHttps + TestConfig.FssPublishHostName + filesBatchDetailHref.AbsolutePath);
             Assert.That(filesBatchDetailHrefReplace.ToString(), Is.Not.Null);
             Assert.That(filesBatchDetailHrefReplace.ToString(), Is.EqualTo(fssEventData.Links.BatchDetails.Href));
         }
@@ -167,62 +163,68 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [TestCase("83d08093-7a67-4b3a-b431-92ba42feaea0", HttpStatusCode.NotFound, TestName = "NotFound for WebHook")]
         public async Task WhenICallTheEnsWebhookApiWithAValidFssJObjectBody_ThenNonOkStatusIsReturned(string subject, HttpStatusCode statusCode)
         {
-            JsonObject ensWebhookJson = FssEventBody;
+            var ensWebhookJson = FssEventBody;
             await StubApiClient.PostStubApiCommandToReturnStatusAsync(ensWebhookJson, subject, statusCode);
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
-            DateTime startTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
+            var startTime = DateTime.UtcNow;
 
             while (DateTime.UtcNow - startTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(10000);
             }
 
-            Assert.That(200, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
-            HttpResponseMessage stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
-            Assert.That(stubResponse.StatusCode,Is.EqualTo(HttpStatusCode.OK));
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
+            var stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
+            Assert.That(stubResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
             // Get the response
-            string customerJsonString = await stubResponse.Content.ReadAsStringAsync();
-            
-            IEnumerable<DistributorRequest> deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString, JOptions);
-            IEnumerable<DistributorRequest> getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode.HasValue && x.StatusCode.Value == statusCode)
-                .OrderByDescending(a => a.TimeStamp);
+            var customerJsonString = await stubResponse.Content.ReadAsStringAsync();
+
+            var deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString, JOptions);
+            var getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode.HasValue && x.StatusCode.Value == statusCode).OrderByDescending(a => a.TimeStamp);
             Assert.That(getMatchingData, Is.Not.Null);
-            Assert.That(getMatchingData.Count() > 1);
+            Assert.That(getMatchingData.Count(), Is.GreaterThan(1));
         }
 
         [Test]
         public async Task WhenICallTheEnsWebhookApiWithAValidScsJObjectBody_ThenOkStatusIsReturned()
         {
             const string subject = "GB53496A";
-            JsonObject ensWebhookJson = ScsEventBody;
+            var ensWebhookJson = ScsEventBody;
             await StubApiClient.PostStubApiCommandToReturnStatusAsync(ensWebhookJson, subject, null);
-            DateTime startTime = DateTime.UtcNow;
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
+            var startTime = DateTime.UtcNow;
+            var apiResponse = await EnsApiClient.PostEnsWebhookNewEventPublishedAsync(ensWebhookJson, EnsToken);
 
             while (DateTime.UtcNow - startTime < TimeSpan.FromSeconds(TestConfig.WaitingTimeForQueueInSeconds))
             {
                 await Task.Delay(10000);
             }
-            Assert.That(200, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
-            HttpResponseMessage stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
+
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(200), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 200.");
+            var stubResponse = await StubApiClient.GetStubApiCacheReturnStatusAsync(subject, EnsToken);
             Assert.That(stubResponse.StatusCode, Is.EqualTo(HttpStatusCode.OK));
-            string customerJsonString = await stubResponse.Content.ReadAsStringAsync();
-            
-            IEnumerable<DistributorRequest> deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString,JOptions);
+            var customerJsonString = await stubResponse.Content.ReadAsStringAsync();
 
-            DistributorRequest getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode.HasValue && x.StatusCode.Value == HttpStatusCode.OK).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
+            var deserialized = JsonSerializer.Deserialize<IEnumerable<DistributorRequest>>(custome‌​rJsonString, JOptions);
+
+            var getMatchingData = deserialized.Where(x => x.TimeStamp >= startTime && x.StatusCode.HasValue && x.StatusCode.Value == HttpStatusCode.OK).OrderByDescending(a => a.TimeStamp).FirstOrDefault();
             Assert.That(getMatchingData, Is.Not.Null);
-            Assert.That(HttpStatusCode.OK, Is.EqualTo(getMatchingData.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(getMatchingData.StatusCode, Is.EqualTo(HttpStatusCode.OK));
 
-            // Validating Event Subject
-            Assert.That(subject, Is.EqualTo(getMatchingData.Subject));
-            Assert.That(getMatchingData.CloudEvent, Is.InstanceOf<CustomCloudEvent>()); 
+                // Validating Event Subject
+                Assert.That(getMatchingData.Subject, Is.EqualTo(subject));
+                Assert.That(getMatchingData.CloudEvent, Is.InstanceOf<CustomCloudEvent>());
+            });
 
-            // Validating Event Source
-            Assert.That(TestConfig.ScsSource, Is.EqualTo(getMatchingData.CloudEvent.Source));
+            Assert.Multiple(() =>
+            {
+                // Validating Event Source
+                Assert.That(getMatchingData.CloudEvent.Source, Is.EqualTo(TestConfig.ScsSource));
 
-            // Validating Event Type
-            Assert.That("uk.co.admiralty.avcsData.contentPublished.v1", Is.EqualTo(getMatchingData.CloudEvent.Type));
+                // Validating Event Type
+                Assert.That(getMatchingData.CloudEvent.Type, Is.EqualTo("uk.co.admiralty.avcsData.contentPublished.v1"));
+            });
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsNotificationConfigurationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsNotificationConfigurationTest.cs
@@ -1,6 +1,5 @@
 ﻿using System.IO;
 using System.Linq;
-using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -9,7 +8,8 @@ using UKHO.ExternalNotificationService.API.FunctionalTests.Model;
 
 namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 {
-    class EnsNotificationConfigurationTest
+    [TestFixture]
+    public class EnsNotificationConfigurationTest
     {
         private EnsApiClient EnsApiClient { get; set; }
         private TestConfiguration TestConfig { get; set; }
@@ -24,7 +24,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             ADAuthTokenProvider adAuthTokenProvider = new();
             EnsToken = await adAuthTokenProvider.GetEnsAuthToken();
 
-            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            var filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
 
             D365Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePath));
             D365Payload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
@@ -33,25 +33,27 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidNotificationType_ThenAcceptedStatusIsReturned()
         {
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(202, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 202.");
-
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 202.");
         }
 
         [TestCase("", "NotificationType cannot be blank or null.", TestName = "Notification Type Value Is Blank")]
         [TestCase(null, "NotificationType cannot be blank or null.", TestName = "Notification Type Value Is Null")]
         [TestCase("ABC", "Invalid Notification Type 'ABC'", TestName = "Notification Type Value Is Invalid And Not Exist In The Configuration")]
-        public async Task WhenICallTheEnsSubscriptionApiWithAnInValidNotificationType_ThenABadRequestStatusIsReturned(string notificationType,string validationMessage)
+        public async Task WhenICallTheEnsSubscriptionApiWithAnInValidNotificationType_ThenABadRequestStatusIsReturned(string notificationType, string validationMessage)
         {
             D365Payload.InputParameters[0].Value.FormattedValues[4].Value = notificationType;
 
-            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
-            Assert.That(400, Is.EqualTo((int)apiResponse.StatusCode), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 400.");
+            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 400.");
 
-            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
-            Assert.That(errorMessage.Errors.Any(e => e.Source == "notificationType"));
-            Assert.That(errorMessage.Errors.Any(e => e.Description == validationMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(errorMessage.Errors.Any(e => e.Source == "notificationType"));
+                Assert.That(errorMessage.Errors.Any(e => e.Description == validationMessage));
+            });
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsNotificationConfigurationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsNotificationConfigurationTest.cs
@@ -1,5 +1,6 @@
 ﻿using System.IO;
 using System.Linq;
+using System.Net.Http;
 using System.Text.Json;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -24,7 +25,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
             ADAuthTokenProvider adAuthTokenProvider = new();
             EnsToken = await adAuthTokenProvider.GetEnsAuthToken();
 
-            var filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
+            string filePath = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
 
             D365Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePath));
             D365Payload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
@@ -33,7 +34,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [Test]
         public async Task WhenICallTheEnsSubscriptionApiWithAValidNotificationType_ThenAcceptedStatusIsReturned()
         {
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 202.");
         }
 
@@ -44,10 +45,10 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         {
             D365Payload.InputParameters[0].Value.FormattedValues[4].Value = notificationType;
 
-            var apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365Payload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(400), $"Incorrect status code {apiResponse.StatusCode} is returned, instead of the expected 400.");
 
-            var errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
+            ErrorDescriptionModel errorMessage = await apiResponse.ReadAsTypeAsync<ErrorDescriptionModel>();
 
             Assert.Multiple(() =>
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -26,6 +26,10 @@
     <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.0.2" />
     <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.1" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -30,7 +30,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Controllers/SubscriptionControllerTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Controllers/SubscriptionControllerTest.cs
@@ -37,7 +37,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         {
             _fakeD365PayloadDetails = GetD365Payload();
             _fakeSubscriptionRequest = GetSubscriptionRequest();
-            _fakeNotificationType = [new() { Name = "Data test", TopicName = "testTopic" }];
+            _fakeNotificationType = new List<NotificationType>() { new NotificationType() { Name = "Data test", TopicName = "testTopic" } };
             _fakeHttpContextAccessor = A.Fake<IHttpContextAccessor>();
             _fakeLogger = A.Fake<ILogger<SubscriptionController>>();
             _fakeSubscriptionService = A.Fake<ISubscriptionService>();
@@ -84,7 +84,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         [Test]
         public async Task WhenD365HttpPayloadSizeExceeded_ThenLogError()
         {
-            var defaultHttpContext = new DefaultHttpContext();
+            DefaultHttpContext defaultHttpContext = new();
             defaultHttpContext.Request.Headers.Append(XmsDynamicsMsgSizeExceededHeader, string.Empty);
             A.CallTo(() => _fakeHttpContextAccessor.HttpContext).Returns(defaultHttpContext);
             A.CallTo(() => _fakeSubscriptionService.ConvertToSubscriptionRequestModel(A<D365Payload>.Ignored)).Returns(_fakeSubscriptionRequest);
@@ -119,7 +119,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         [Test]
         public async Task WhenPostValidPayload_ThenReceiveSuccessfulResponse()
         {
-            var defaultHttpContext = new DefaultHttpContext();
+            DefaultHttpContext defaultHttpContext = new();
             defaultHttpContext.Request.Headers.Append(CorrelationIdMiddleware.XCorrelationIdHeaderKey, value: Guid.NewGuid().ToString());
             A.CallTo(() => _fakeHttpContextAccessor.HttpContext).Returns(defaultHttpContext);
 
@@ -136,11 +136,11 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
 
         private static D365Payload GetD365Payload()
         {
-            var d365Payload = new D365Payload
+            var d365Payload = new D365Payload()
             {
                 CorrelationId = "6ea03f10-2672-46fb-92a1-5200f6a4fabc",
-                InputParameters = [],
-                PostEntityImages = [],
+                InputParameters = Array.Empty<InputParameter>(),
+                PostEntityImages = Array.Empty<EntityImage>(),
                 OperationCreatedOn = "/Date(1642149320000+0000)/"
             };
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Controllers/WebhookControllerTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Controllers/WebhookControllerTest.cs
@@ -1,4 +1,5 @@
-﻿using System.IO;
+﻿using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -32,7 +33,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         [SetUp]
         public void Setup()
         {
-            var jsonString = JsonSerializer.Serialize(CustomCloudEventBase.GetCustomCloudEvent());
+            string jsonString = JsonSerializer.Serialize(CustomCloudEventBase.GetCustomCloudEvent());
             _fakeFssEventBodyData = new MemoryStream(Encoding.UTF8.GetBytes(jsonString));
             _fakeLogger = A.Fake<ILogger<WebhookController>>();
             _fakeHttpContextAccessor = A.Fake<IHttpContextAccessor>();
@@ -47,7 +48,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         public void WhenValidHeaderRequestedInNewFilesPublishedOptions_ThenReturnsOkResponse()
         {
             var context = new DefaultHttpContext();
-            var requestHeaderValue = "test.example.com";
+            string requestHeaderValue = "test.example.com";
             context.Request.Headers["WebHook-Request-Origin"] = requestHeaderValue;
 
             A.CallTo(() => _fakeHttpContextAccessor.HttpContext).Returns(context);
@@ -71,7 +72,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
         [Test]
         public async Task WhenPostFssNullEventInRequest_ThenReceiveSuccessfulResponse()
         {
-            var jsonString = JsonSerializer.Serialize(new JsonObject());
+            string jsonString = JsonSerializer.Serialize(new JsonObject());
             var requestData = new MemoryStream(Encoding.UTF8.GetBytes(jsonString));
 
             _controller.ControllerContext.HttpContext = new DefaultHttpContext();
@@ -105,7 +106,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Controllers
             A.CallTo(() => _fakeEventProcessor.Process(A<CustomCloudEvent>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
                            .Returns(new ExternalNotificationServiceProcessResponse()
                            {
-                               Errors = [new() { Description = "test", Source = "test" }],
+                               Errors = new List<Error>() { new Error() { Description = "test", Source = "test" } },
                                StatusCode = HttpStatusCode.OK
                            });
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventProcessorTest.cs
@@ -14,6 +14,7 @@ using UKHO.ExternalNotificationService.Common.Exceptions;
 using UKHO.ExternalNotificationService.Common.Helpers;
 using UKHO.ExternalNotificationService.Common.Models.EventModel;
 using UKHO.ExternalNotificationService.Common.Models.Request;
+using UKHO.ExternalNotificationService.Common.Models.Response;
 
 namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 {
@@ -44,7 +45,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public void WhenValidInRequest_ThenReceiveEventType()
         {
-            var result = _fssEventProcessor.EventType;
+            string result = _fssEventProcessor.EventType;
 
             Assert.That(result, Is.EqualTo(_fakeCustomCloudEvent.Type));
         }
@@ -60,7 +61,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
             A.CallTo(() => _fakeFssEventValidationAndMappingService.ValidateFssEventData(A<FssEventData>.Ignored))
                             .Returns(new ValidationResult(new List<ValidationFailure> { validationMessage }));
 
-            var result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId);
+            ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId);
 
             Assert.Multiple(() =>
             {
@@ -72,8 +73,8 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public async Task WhenDiscardedBusinessUnitInRequest_ThenReceiveSuccessfulResponse()
         {
-            var cancellationToken = CancellationToken.None;
-            var cloudEvent = new CloudEvent("test", "test", new object());
+            CancellationToken cancellationToken = CancellationToken.None;
+            CloudEvent cloudEvent = new("test", "test", new object());
             _fakeFssEventData.BusinessUnit = "test";
 
             A.CallTo(() => _fakeFssEventValidationAndMappingService.ValidateFssEventData(A<FssEventData>.Ignored)).Returns(new ValidationResult());
@@ -84,7 +85,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(A<CloudEvent>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored));
 
-            var result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
+            ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
 
             Assert.Multiple(() =>
             {
@@ -97,7 +98,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public async Task WhenUnconfiguredBusinessUnitInRequest_ThenReceiveSuccessfulResponse()
         {
-            var cancellationToken = CancellationToken.None;
+            CancellationToken cancellationToken = CancellationToken.None;
 
             A.CallTo(() => _fakeAzureEventGridDomainService.ConvertObjectTo<FssEventData>(_fakeCustomCloudEvent.Data)).Returns(_fakeFssEventData);
 
@@ -105,7 +106,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             A.CallTo(() => _fakeFssEventValidationAndMappingService.MapToCloudEvent(A<CloudEventCandidate<FssEventData>>.Ignored)).Throws<ConfigurationMissingException>();
 
-            var result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
+            ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(_fakeCustomCloudEvent, CorrelationId, cancellationToken);
 
             Assert.Multiple(() =>
             {
@@ -125,10 +126,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [TestCase("MaritimeSafetyInformation")]
         public async Task WhenValidPayloadInRequest_ThenReceiveSuccessfulResponse(string businessUnit)
         {
-            var cancellationToken = CancellationToken.None;
-            var cloudEvent = new CloudEvent("test", "test", new object());
-            var customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
-            var fssEventData = CustomCloudEventBase.GetFssEventData(businessUnit);
+            CancellationToken cancellationToken = CancellationToken.None;
+            CloudEvent cloudEvent = new("test", "test", new object());
+            CustomCloudEvent customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
+            FssEventData fssEventData = CustomCloudEventBase.GetFssEventData(businessUnit);
 
             A.CallTo(() => _fakeFssEventValidationAndMappingService.ValidateFssEventData(A<FssEventData>.Ignored)).Returns(new ValidationResult());
 
@@ -138,7 +139,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
 
             A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(A<CloudEvent>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored));
 
-            var result = await _fssEventProcessor.Process(customCloudEvent, CorrelationId, cancellationToken);
+            ExternalNotificationServiceProcessResponse result = await _fssEventProcessor.Process(customCloudEvent, CorrelationId, cancellationToken);
 
             Assert.Multiple(() =>
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventValidationAndMappingServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventValidationAndMappingServiceTest.cs
@@ -25,21 +25,18 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         private IOptions<FssDataMappingConfiguration> _fakeFssDataMappingConfiguration;
         private FssEventValidationAndMappingService _fssEventValidationAndMappingService;
         private FssEventData _fakeFssEventData;
-        private CustomCloudEvent _fakeCustomCloudEvent;
 
         [SetUp]
         public void Setup()
         {
             _fakeFssEventData = CustomCloudEventBase.GetFssEventData();
-            _fakeCustomCloudEvent = CustomCloudEventBase.GetCustomCloudEvent();
             _fakeFssEventDataValidator = A.Fake<IFssEventDataValidator>();
             _fakeFssDataMappingConfiguration = A.Fake<IOptions<FssDataMappingConfiguration>>();
             _fakeFssDataMappingConfiguration.Value.Sources =
-                new List<FssDataMappingConfiguration.SourceConfiguration>
-                {
+                [
                     new() {BusinessUnit = "AVCSData", Source = "fss-AVCSData"},
                     new() {BusinessUnit = "MaritimeSafetyInformation", Source = "fss-MaritimeSafetyInformation"},
-                };
+                ];
             _fakeFssDataMappingConfiguration.Value.EventHostName = "files.admiralty.co.uk";
             _fakeFssDataMappingConfiguration.Value.PublishHostName = "test/fss";
 
@@ -49,13 +46,15 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public async Task WhenNullBatchIdInRequest_ThenReceiveSuccessfulResponse()
         {
-            A.CallTo(() => _fakeFssEventDataValidator.Validate(A<FssEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>
-                    {new ValidationFailure("BatchId", "BatchId cannot be blank or null.")}));
+            A.CallTo(() => _fakeFssEventDataValidator.Validate(A<FssEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure> { new("BatchId", "BatchId cannot be blank or null.") }));
 
-            ValidationResult result = await _fssEventValidationAndMappingService.ValidateFssEventData(new FssEventData());
+            var result = await _fssEventValidationAndMappingService.ValidateFssEventData(new FssEventData());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("BatchId cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("BatchId cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -63,7 +62,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeFssEventDataValidator.Validate(A<FssEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            ValidationResult result = await _fssEventValidationAndMappingService.ValidateFssEventData(_fakeFssEventData);
+            var result = await _fssEventValidationAndMappingService.ValidateFssEventData(_fakeFssEventData);
 
             Assert.That(result.IsValid);
         }
@@ -74,26 +73,29 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             const string batchDetailsUri = "https://test/fss/batch/83d08093-7a67-4b3a-b431-92ba42feaea0";
 
-            CustomCloudEvent customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
-            CloudEventCandidate<FssEventData> candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
-            CloudEvent result = _fssEventValidationAndMappingService.MapToCloudEvent(candidate);
+            var customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
+            var candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
+            var result = _fssEventValidationAndMappingService.MapToCloudEvent(candidate);
 
-            string data = Encoding.ASCII.GetString(result.Data);
-            FssEventData cloudEventData = JsonSerializer.Deserialize<FssEventData>(data);
+            var data = Encoding.ASCII.GetString(result.Data);
+            var cloudEventData = JsonSerializer.Deserialize<FssEventData>(data);
 
-            Assert.That(FssDataMappingValueConstant.Type, Is.EqualTo(result.Type));
-            Assert.That(_fakeFssDataMappingConfiguration.Value.Sources.Single(x => x.BusinessUnit == businessUnit).Source, Is.EqualTo(result.Source));
-            Assert.That(batchDetailsUri, Is.EqualTo(cloudEventData.Links.BatchDetails.Href));
-            Assert.That(batchDetailsUri + "/status", Is.EqualTo(cloudEventData.Links.BatchStatus.Href));
-            Assert.That(batchDetailsUri + "/files/AVCS_S631-1_Update_Wk45_21_Only.zip", Is.EqualTo(cloudEventData.Files.FirstOrDefault().Links.Get.Href));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Type, Is.EqualTo(FssDataMappingValueConstant.Type));
+                Assert.That(result.Source, Is.EqualTo(_fakeFssDataMappingConfiguration.Value.Sources.Single(x => x.BusinessUnit == businessUnit).Source));
+                Assert.That(cloudEventData.Links.BatchDetails.Href, Is.EqualTo(batchDetailsUri));
+                Assert.That(cloudEventData.Links.BatchStatus.Href, Is.EqualTo(batchDetailsUri + "/status"));
+                Assert.That(cloudEventData.Files.FirstOrDefault().Links.Get.Href, Is.EqualTo(batchDetailsUri + "/files/AVCS_S631-1_Update_Wk45_21_Only.zip"));
+            });
         }
 
         [Test]
         public void WhenFssEventDataMappingRequestForUnconfiguredBusinessUnit_ThenThrowConfigurationMissingException()
         {
             const string businessUnit = "UnconfiguredBusinessUnit";
-            CustomCloudEvent customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
-            CloudEventCandidate<FssEventData> candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
+            var customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
+            var candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
 
             Assert.Throws(Is.TypeOf<ConfigurationMissingException>().And.Message.EqualTo($"Missing FssDataMappingConfiguration configuration for {businessUnit} business unit"),
                 delegate

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventValidationAndMappingServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/FssEventValidationAndMappingServiceTest.cs
@@ -48,7 +48,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeFssEventDataValidator.Validate(A<FssEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure> { new("BatchId", "BatchId cannot be blank or null.") }));
 
-            var result = await _fssEventValidationAndMappingService.ValidateFssEventData(new FssEventData());
+            ValidationResult result = await _fssEventValidationAndMappingService.ValidateFssEventData(new FssEventData());
 
             Assert.Multiple(() =>
             {
@@ -62,7 +62,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeFssEventDataValidator.Validate(A<FssEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            var result = await _fssEventValidationAndMappingService.ValidateFssEventData(_fakeFssEventData);
+            ValidationResult result = await _fssEventValidationAndMappingService.ValidateFssEventData(_fakeFssEventData);
 
             Assert.That(result.IsValid);
         }
@@ -73,12 +73,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             const string batchDetailsUri = "https://test/fss/batch/83d08093-7a67-4b3a-b431-92ba42feaea0";
 
-            var customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
-            var candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
-            var result = _fssEventValidationAndMappingService.MapToCloudEvent(candidate);
+            CustomCloudEvent customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
+            CloudEventCandidate<FssEventData> candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
+            CloudEvent result = _fssEventValidationAndMappingService.MapToCloudEvent(candidate);
 
-            var data = Encoding.ASCII.GetString(result.Data);
-            var cloudEventData = JsonSerializer.Deserialize<FssEventData>(data);
+            string data = Encoding.ASCII.GetString(result.Data);
+            FssEventData cloudEventData = JsonSerializer.Deserialize<FssEventData>(data);
 
             Assert.Multiple(() =>
             {
@@ -94,8 +94,8 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         public void WhenFssEventDataMappingRequestForUnconfiguredBusinessUnit_ThenThrowConfigurationMissingException()
         {
             const string businessUnit = "UnconfiguredBusinessUnit";
-            var customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
-            var candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
+            CustomCloudEvent customCloudEvent = CustomCloudEventBase.GetCustomCloudEvent(businessUnit);
+            CloudEventCandidate<FssEventData> candidate = CustomCloudEventBase.GetCloudEventCandidate<FssEventData>(customCloudEvent);
 
             Assert.Throws(Is.TypeOf<ConfigurationMissingException>().And.Message.EqualTo($"Missing FssDataMappingConfiguration configuration for {businessUnit} business unit"),
                 delegate

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventValidationAndMappingServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventValidationAndMappingServiceTest.cs
@@ -3,7 +3,6 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
-using Azure.Messaging;
 using FakeItEasy;
 using FluentValidation.Results;
 using Microsoft.Extensions.Options;
@@ -26,12 +25,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         private ScsEventData _fakeScsEventData;
         private CustomCloudEvent _fakeCustomCloudEvent;
         private CloudEventCandidate<ScsEventData> _fakeCloudEventCandidate;
-        
 
         [SetUp]
         public void Setup()
         {
-            
             _fakeScsEventData = CustomCloudEventBase.GetScsEventData();
             _fakeCustomCloudEvent = CustomCloudEventBase.GetCustomCloudEvent();
             _fakeCustomCloudEvent.Data = _fakeScsEventData;
@@ -48,12 +45,15 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         public async Task WhenNullBatchIdInRequest_ThenReceiveSuccessfulResponse()
         {
             A.CallTo(() => _fakeScsEventDataValidator.Validate(A<ScsEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>
-                    {new ValidationFailure("ProductType", "ProductType cannot be blank or null.")}));
+                    { new("ProductType", "ProductType cannot be blank or null.") }));
 
-            ValidationResult result = await _scsEventValidationAndMappingService.ValidateScsEventData(new ScsEventData());
+            var result = await _scsEventValidationAndMappingService.ValidateScsEventData(new ScsEventData());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("ProductType cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("ProductType cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -61,7 +61,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeScsEventDataValidator.Validate(A<ScsEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            ValidationResult result = await _scsEventValidationAndMappingService.ValidateScsEventData(_fakeScsEventData);
+            var result = await _scsEventValidationAndMappingService.ValidateScsEventData(_fakeScsEventData);
 
             Assert.That(result.IsValid);
         }
@@ -71,14 +71,17 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public void WhenValidScsEventDataMappingRequest_ThenReturnCloudEvent()
         {
-            CloudEvent result = _scsEventValidationAndMappingService.MapToCloudEvent(_fakeCloudEventCandidate);
+            var result = _scsEventValidationAndMappingService.MapToCloudEvent(_fakeCloudEventCandidate);
 
-            string data = Encoding.ASCII.GetString(result.Data);
-            ScsEventData cloudEventData = JsonSerializer.Deserialize<ScsEventData>(data);
+            var data = Encoding.ASCII.GetString(result.Data);
+            var cloudEventData = JsonSerializer.Deserialize<ScsEventData>(data);
 
-            Assert.That(ScsDataMappingValueConstant.Type, Is.EqualTo(result.Type));
-            Assert.That(_fakeScsDataMappingConfiguration.Value.Source, Is.EqualTo(result.Source));
-            Assert.That(_fakeScsEventData.ProductType, Is.EqualTo(cloudEventData.ProductType));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Type, Is.EqualTo(ScsDataMappingValueConstant.Type));
+                Assert.That(result.Source, Is.EqualTo(_fakeScsDataMappingConfiguration.Value.Source));
+                Assert.That(cloudEventData.ProductType, Is.EqualTo(_fakeScsEventData.ProductType));
+            });
         }
         #endregion
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventValidationAndMappingServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/ScsEventValidationAndMappingServiceTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Azure.Messaging;
 using FakeItEasy;
 using FluentValidation.Results;
 using Microsoft.Extensions.Options;
@@ -45,9 +46,9 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         public async Task WhenNullBatchIdInRequest_ThenReceiveSuccessfulResponse()
         {
             A.CallTo(() => _fakeScsEventDataValidator.Validate(A<ScsEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>
-                    { new("ProductType", "ProductType cannot be blank or null.") }));
+                    { new ValidationFailure("ProductType", "ProductType cannot be blank or null.") }));
 
-            var result = await _scsEventValidationAndMappingService.ValidateScsEventData(new ScsEventData());
+            ValidationResult result = await _scsEventValidationAndMappingService.ValidateScsEventData(new ScsEventData());
 
             Assert.Multiple(() =>
             {
@@ -61,7 +62,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeScsEventDataValidator.Validate(A<ScsEventData>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            var result = await _scsEventValidationAndMappingService.ValidateScsEventData(_fakeScsEventData);
+            ValidationResult result = await _scsEventValidationAndMappingService.ValidateScsEventData(_fakeScsEventData);
 
             Assert.That(result.IsValid);
         }
@@ -71,10 +72,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public void WhenValidScsEventDataMappingRequest_ThenReturnCloudEvent()
         {
-            var result = _scsEventValidationAndMappingService.MapToCloudEvent(_fakeCloudEventCandidate);
+            CloudEvent result = _scsEventValidationAndMappingService.MapToCloudEvent(_fakeCloudEventCandidate);
 
-            var data = Encoding.ASCII.GetString(result.Data);
-            var cloudEventData = JsonSerializer.Deserialize<ScsEventData>(data);
+            string data = Encoding.ASCII.GetString(result.Data);
+            ScsEventData cloudEventData = JsonSerializer.Deserialize<ScsEventData>(data);
 
             Assert.Multiple(() =>
             {

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/SubscriptionServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Services/SubscriptionServiceTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using FakeItEasy;
@@ -22,7 +21,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         private D365Payload _d365PayloadDetails;
         private SubscriptionRequest _subscriptionRequest;
         private NotificationType _notificationType;
-        private ISubscriptionService _subscriptionService;
+        private SubscriptionService _subscriptionService;
         private IAzureMessageQueueHelper _fakeAzureMessageQueueHelper;
         private IOptions<SubscriptionStorageConfiguration> _fakeEnsStorageConfiguration;
         private ILogger<SubscriptionService> _fakeLogger;
@@ -49,12 +48,15 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         public async Task WhenInvalidPayloadWithNullInputParameters_ThenReceiveBadrequest()
         {
             A.CallTo(() => _fakeD365PayloadValidator.Validate(A<D365Payload>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>
-                    {new ValidationFailure("InputParameters", "D365Payload InputParameters cannot be blank or null.")}));
+                    { new("InputParameters", "D365Payload InputParameters cannot be blank or null.") }));
 
-            ValidationResult result = await _subscriptionService.ValidateD365PayloadRequest(new D365Payload());
+            var result = await _subscriptionService.ValidateD365PayloadRequest(new D365Payload());
 
-            Assert.That(result.IsValid, Is.False);
-            Assert.That("D365Payload InputParameters cannot be blank or null.", Is.EqualTo(result.Errors.Single().ErrorMessage));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsValid, Is.False);
+                Assert.That(result.Errors.Single().ErrorMessage, Is.EqualTo("D365Payload InputParameters cannot be blank or null."));
+            });
         }
 
         [Test]
@@ -62,7 +64,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             A.CallTo(() => _fakeD365PayloadValidator.Validate(A<D365Payload>.Ignored)).Returns(new ValidationResult(new List<ValidationFailure>()));
 
-            ValidationResult result = await _subscriptionService.ValidateD365PayloadRequest(_d365PayloadDetails);
+            var result = await _subscriptionService.ValidateD365PayloadRequest(_d365PayloadDetails);
 
             Assert.That(result.IsValid);
         }
@@ -73,50 +75,60 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         [Test]
         public void WhenInvalidPayloadWithoutStateCodeKey_ThenReceiveSubscriptionRequestWithFalseIsActive()
         {
-            _d365PayloadDetails.InputParameters[0].Value.FormattedValues = new FormattedValue[]
-                                                                            { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey,
-                                                                                                   Value = "Data test" }};
-            _d365PayloadDetails.PostEntityImages = Array.Empty<EntityImage>();
+            _d365PayloadDetails.InputParameters[0].Value.FormattedValues = [new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" }];
+            _d365PayloadDetails.PostEntityImages = [];
 
-            SubscriptionRequest result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
+            var result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
 
-            Assert.That(result.IsActive, Is.False);
-            Assert.That(result, Is.InstanceOf<SubscriptionRequest>());
-            Assert.That(_subscriptionRequest.SubscriptionId, Is.EqualTo(result.SubscriptionId));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.IsActive, Is.False);
+                Assert.That(result, Is.InstanceOf<SubscriptionRequest>());
+            });
+            Assert.That(result.SubscriptionId, Is.EqualTo(_subscriptionRequest.SubscriptionId));
         }
 
         [Test]
         public void WhenValidPayloadWithNullPostEntityImages_ThenReceiveSuccessfulSubscriptionRequest()
         {
-            _d365PayloadDetails.PostEntityImages = Array.Empty<EntityImage>();
-            SubscriptionRequest result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
+            _d365PayloadDetails.PostEntityImages = [];
+            var result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
 
             Assert.That(result, Is.InstanceOf<SubscriptionRequest>());
-            Assert.That(_subscriptionRequest.SubscriptionId, Is.EqualTo(result.SubscriptionId));
-            Assert.That(_subscriptionRequest.NotificationType, Is.EqualTo(result.NotificationType));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.SubscriptionId, Is.EqualTo(_subscriptionRequest.SubscriptionId));
+                Assert.That(result.NotificationType, Is.EqualTo(_subscriptionRequest.NotificationType));
+            });
         }
 
         [Test]
         public void WhenValidPayloadWithNullPostEntityImagesValue_ThenReceiveSuccessfulSubscriptionRequest()
         {
             _d365PayloadDetails.PostEntityImages[0].Value = null;
-            SubscriptionRequest result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
+            var result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
 
             Assert.That(result, Is.InstanceOf<SubscriptionRequest>());
-            Assert.That(_subscriptionRequest.SubscriptionId, Is.EqualTo(result.SubscriptionId));
-            Assert.That(_subscriptionRequest.NotificationType, Is.EqualTo(result.NotificationType));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.SubscriptionId, Is.EqualTo(_subscriptionRequest.SubscriptionId));
+                Assert.That(result.NotificationType, Is.EqualTo(_subscriptionRequest.NotificationType));
+            });
         }
 
         [Test]
         public void WhenValidPayloadInRequest_ThenReceiveSubscriptionRequest()
         {
-            SubscriptionRequest result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
+            var result = _subscriptionService.ConvertToSubscriptionRequestModel(_d365PayloadDetails);
 
             Assert.That(result, Is.InstanceOf<SubscriptionRequest>());
-            Assert.That(_subscriptionRequest.SubscriptionId, Is.EqualTo(result.SubscriptionId));
-            Assert.That(_subscriptionRequest.NotificationType, Is.EqualTo(result.NotificationType));
-            Assert.That(_subscriptionRequest.IsActive, Is.EqualTo(result.IsActive));
-            Assert.That(_subscriptionRequest.WebhookUrl, Is.EqualTo(result.WebhookUrl));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.SubscriptionId, Is.EqualTo(_subscriptionRequest.SubscriptionId));
+                Assert.That(result.NotificationType, Is.EqualTo(_subscriptionRequest.NotificationType));
+                Assert.That(result.IsActive, Is.EqualTo(_subscriptionRequest.IsActive));
+                Assert.That(result.WebhookUrl, Is.EqualTo(_subscriptionRequest.WebhookUrl));
+            });
         }
         #endregion
 
@@ -125,7 +137,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
         {
             const string correlationId = "6ea03f10-2672-46fb-92a1-5200f6a4faaa";
 
-            Task result = _subscriptionService.AddSubscriptionRequest(_subscriptionRequest, _notificationType, correlationId);
+            var result = _subscriptionService.AddSubscriptionRequest(_subscriptionRequest, _notificationType, correlationId);
 
             A.CallTo(() => _fakeAzureMessageQueueHelper.AddQueueMessage(_fakeEnsStorageConfiguration.Value, A<SubscriptionRequestMessage>.Ignored)).MustHaveHappenedOnceExactly();
             Assert.That(result.IsCompleted);
@@ -136,19 +148,19 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Services
             var d365Payload = new D365Payload()
             {
                 CorrelationId = "6ea03f10-2672-46fb-92a1-5200f6a4faaa",
-                InputParameters = new InputParameter[] { new InputParameter {
-                                    Value = new InputParameterValue {
-                                                Attributes = new D365Attribute[] {  new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                                                    new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
-                                                FormattedValues = new FormattedValue[] {new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                                        new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
-                PostEntityImages = new EntityImage[] { new EntityImage {
+                InputParameters = [new() {
+                                   Value = new InputParameterValue {
+                                               Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                             new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
+                                               FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                  new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
+                PostEntityImages = [new() {
                                     Key= D365PayloadKeyConstant.PostEntityImageKey,
                                     Value = new EntityImageValue {
-                                        Attributes = new D365Attribute[] { new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                                           new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
-                                        FormattedValues = new FormattedValue[] { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                                 new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
+                                                Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                              new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
+                                                FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                   new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
                 OperationCreatedOn = "/Date(1642149320000+0000)/"
             };
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
@@ -17,6 +17,10 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.13" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.13" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
@@ -21,7 +21,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/D365PayloadValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/D365PayloadValidatorTest.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
 using UKHO.ExternalNotificationService.API.Validation;
@@ -26,7 +27,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.CorrelationId = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("CorrelationId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload CorrelationId cannot be blank or null."));
@@ -37,7 +38,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.CorrelationId = string.Empty;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("CorrelationId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload CorrelationId cannot be blank or null."));
@@ -50,7 +51,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("InputParameters");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload InputParameters cannot be blank or null."));
@@ -61,7 +62,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.PostEntityImages = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("PostEntityImages");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload PostEntityImages cannot be blank or null."));
@@ -72,10 +73,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutSubscriptionIdKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://input.com" }];
+            _fakeD365Payload.InputParameters[0].Value.Attributes = new D365Attribute[]
+                                                                    { new D365Attribute {Key = D365PayloadKeyConstant.WebhookUrlKey,
+                                                                                         Value = "https://input.com" } };
             _fakeD365Payload.PostEntityImages[0].Value.Attributes = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("SubscriptionId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "SubscriptionId cannot be blank or null."));
@@ -86,7 +89,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.Attributes[1].Value = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("SubscriptionId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "SubscriptionId cannot be blank or null."));
@@ -98,10 +101,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutNotificationTypeKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.FormattedValues = [new() { Key = D365PayloadKeyConstant.IsActiveKey, Value = "Active" }];
+            _fakeD365Payload.InputParameters[0].Value.FormattedValues = new FormattedValue[]
+                                                                        { new FormattedValue { Key = D365PayloadKeyConstant.IsActiveKey,
+                                                                                               Value = "Active" } };
             _fakeD365Payload.PostEntityImages[0].Value.FormattedValues = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("NotificationType");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "NotificationType cannot be blank or null."));
@@ -112,7 +117,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.FormattedValues[0].Value = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("NotificationType");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "NotificationType cannot be blank or null."));
@@ -123,10 +128,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutWebhookUrlKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.Attributes = [new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }];
+            _fakeD365Payload.InputParameters[0].Value.Attributes = new D365Attribute[]
+                                                                    { new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey,
+                                                                                          Value = "246d71e7-1475-ec11-8943-002248818222" } };
             _fakeD365Payload.PostEntityImages[0].Value.Attributes = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("WebhookUrl");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "WebhookUrl cannot be blank or null."));
@@ -137,7 +144,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.Attributes[0].Value = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("WebhookUrl");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "WebhookUrl cannot be blank or null."));
@@ -148,10 +155,12 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutStateCodeKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" }];
+            _fakeD365Payload.InputParameters[0].Value.FormattedValues = new FormattedValue[]
+                                                                        { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey,
+                                                                                               Value = "Data test" } };
             _fakeD365Payload.PostEntityImages[0].Value.FormattedValues = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("StateCode");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "StateCode cannot be blank or null."));
@@ -162,7 +171,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.FormattedValues[1].Value = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("StateCode");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "StateCode cannot be blank or null."));
@@ -173,7 +182,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequestD365Payload_ThenReceiveSuccessfulResponse()
         {
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
             Assert.That(result.Errors, Is.Empty);
         }
@@ -181,8 +190,8 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequestWithNullPostEntityImages_ThenReceiveSuccessfulResponse()
         {
-            _fakeD365Payload.PostEntityImages = [];
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            _fakeD365Payload.PostEntityImages = Array.Empty<EntityImage>();
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
             Assert.That(result.Errors, Is.Empty);
         }
@@ -192,7 +201,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.PostEntityImages[0].Value = null;
 
-            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
             Assert.That(result.Errors, Is.Empty);
         }
@@ -203,19 +212,19 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             var d365Payload = new D365Payload()
             {
                 CorrelationId = "6ea03f10-2672-46fb-92a1-5200f6a4faaa",
-                InputParameters = [new() {
-                                   Value = new InputParameterValue {
-                                               Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                             new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
-                                               FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                  new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
-                PostEntityImages = [new() {
-                                    Key = D365PayloadKeyConstant.PostEntityImageKey,
+                InputParameters = new InputParameter[] { new InputParameter {
+                                    Value = new InputParameterValue {
+                                                Attributes = new D365Attribute[] {  new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                                                    new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
+                                                FormattedValues = new FormattedValue[] {new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                                        new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
+                PostEntityImages = new EntityImage[] { new EntityImage {
+                                    Key= D365PayloadKeyConstant.PostEntityImageKey,
                                     Value = new EntityImageValue {
-                                                Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                              new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
-                                                FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                   new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
+                                        Attributes = new D365Attribute[] { new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                                           new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
+                                        FormattedValues = new FormattedValue[] { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                                 new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
                 OperationCreatedOn = "/Date(1642149320000+0000)/"
             };
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/D365PayloadValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/D365PayloadValidatorTest.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using FluentValidation.TestHelper;
 using NUnit.Framework;
 using UKHO.ExternalNotificationService.API.Validation;
@@ -27,7 +26,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.CorrelationId = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("CorrelationId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload CorrelationId cannot be blank or null."));
@@ -38,7 +37,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.CorrelationId = string.Empty;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("CorrelationId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload CorrelationId cannot be blank or null."));
@@ -51,7 +50,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("InputParameters");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload InputParameters cannot be blank or null."));
@@ -62,7 +61,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.PostEntityImages = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("PostEntityImages");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "D365Payload PostEntityImages cannot be blank or null."));
@@ -73,12 +72,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutSubscriptionIdKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.Attributes = new D365Attribute[]
-                                                                    { new D365Attribute {Key = D365PayloadKeyConstant.WebhookUrlKey,
-                                                                                         Value = "https://input.com" } };
+            _fakeD365Payload.InputParameters[0].Value.Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://input.com" }];
             _fakeD365Payload.PostEntityImages[0].Value.Attributes = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("SubscriptionId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "SubscriptionId cannot be blank or null."));
@@ -89,7 +86,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.Attributes[1].Value = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("SubscriptionId");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "SubscriptionId cannot be blank or null."));
@@ -101,12 +98,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutNotificationTypeKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.FormattedValues = new FormattedValue[]
-                                                                        { new FormattedValue { Key = D365PayloadKeyConstant.IsActiveKey,
-                                                                                               Value = "Active" } };
+            _fakeD365Payload.InputParameters[0].Value.FormattedValues = [new() { Key = D365PayloadKeyConstant.IsActiveKey, Value = "Active" }];
             _fakeD365Payload.PostEntityImages[0].Value.FormattedValues = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("NotificationType");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "NotificationType cannot be blank or null."));
@@ -117,7 +112,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.FormattedValues[0].Value = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("NotificationType");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "NotificationType cannot be blank or null."));
@@ -128,12 +123,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutWebhookUrlKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.Attributes = new D365Attribute[]
-                                                                    { new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey,
-                                                                                          Value = "246d71e7-1475-ec11-8943-002248818222" } };
+            _fakeD365Payload.InputParameters[0].Value.Attributes = [new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }];
             _fakeD365Payload.PostEntityImages[0].Value.Attributes = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("WebhookUrl");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "WebhookUrl cannot be blank or null."));
@@ -144,7 +137,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.Attributes[0].Value = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("WebhookUrl");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "WebhookUrl cannot be blank or null."));
@@ -155,12 +148,10 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenRequestWithoutStateCodeKey_ThenReceiveBadRequest()
         {
-            _fakeD365Payload.InputParameters[0].Value.FormattedValues = new FormattedValue[]
-                                                                        { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey,
-                                                                                               Value = "Data test" } };
+            _fakeD365Payload.InputParameters[0].Value.FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" }];
             _fakeD365Payload.PostEntityImages[0].Value.FormattedValues = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("StateCode");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "StateCode cannot be blank or null."));
@@ -171,7 +162,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.InputParameters[0].Value.FormattedValues[1].Value = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
             result.ShouldHaveValidationErrorFor("StateCode");
 
             Assert.That(result.Errors.Any(x => x.ErrorMessage == "StateCode cannot be blank or null."));
@@ -182,18 +173,18 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequestD365Payload_ThenReceiveSuccessfulResponse()
         {
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
 
         [Test]
         public void WhenValidRequestWithNullPostEntityImages_ThenReceiveSuccessfulResponse()
         {
-            _fakeD365Payload.PostEntityImages = Array.Empty<EntityImage>();
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            _fakeD365Payload.PostEntityImages = [];
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
 
         [Test]
@@ -201,9 +192,9 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeD365Payload.PostEntityImages[0].Value = null;
 
-            TestValidationResult<D365Payload> result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
+            var result = _d365PayloadValidator.TestValidate(_fakeD365Payload);
 
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
         #endregion
 
@@ -212,19 +203,19 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
             var d365Payload = new D365Payload()
             {
                 CorrelationId = "6ea03f10-2672-46fb-92a1-5200f6a4faaa",
-                InputParameters = new InputParameter[] { new InputParameter {
-                                    Value = new InputParameterValue {
-                                                Attributes = new D365Attribute[] {  new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                                                    new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
-                                                FormattedValues = new FormattedValue[] {new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                                        new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
-                PostEntityImages = new EntityImage[] { new EntityImage {
-                                    Key= D365PayloadKeyConstant.PostEntityImageKey,
+                InputParameters = [new() {
+                                   Value = new InputParameterValue {
+                                               Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                             new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
+                                               FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                  new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
+                PostEntityImages = [new() {
+                                    Key = D365PayloadKeyConstant.PostEntityImageKey,
                                     Value = new EntityImageValue {
-                                        Attributes = new D365Attribute[] { new D365Attribute { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
-                                                                           new D365Attribute { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" } },
-                                        FormattedValues = new FormattedValue[] { new FormattedValue { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
-                                                                                 new FormattedValue { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }}}}},
+                                                Attributes = [new() { Key = D365PayloadKeyConstant.WebhookUrlKey, Value = "https://abc.com" },
+                                                              new() { Key = D365PayloadKeyConstant.SubscriptionIdKey, Value = "246d71e7-1475-ec11-8943-002248818222" }],
+                                                FormattedValues = [new() { Key = D365PayloadKeyConstant.NotificationTypeKey, Value = "Data test" },
+                                                                   new() { Key =  D365PayloadKeyConstant.IsActiveKey, Value = "Active" }]}}],
                 OperationCreatedOn = "/Date(1642149320000+0000)/"
             };
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/FssEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/FssEventDataValidatorTest.cs
@@ -26,11 +26,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BatchId = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchId");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "BatchId cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "BatchId cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -40,11 +43,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BusinessUnit = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BusinessUnit");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Business unit cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Business unit cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -54,11 +60,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BatchPublishedDate = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchPublishedDate");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Batch published date cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Batch published date cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -68,11 +77,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Links");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links detail cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links detail cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -82,11 +94,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchDetails = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchDetails");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch detail cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch detail cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -96,11 +111,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchStatus = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchStatus");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch status cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch status cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -110,11 +128,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchDetails.Href = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchDetailsUri");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch detail uri cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch detail uri cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -124,11 +145,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchStatus.Href = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchStatusUri");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch status uri cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Links batch status uri cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -138,11 +162,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().Links = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Links");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "File links cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "File links cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -152,11 +179,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().MIMEType = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("MIMEType");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "File MIME type cannot be null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "File MIME type cannot be null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -166,11 +196,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().Hash = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Hash");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "File hash cannot be null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "File hash cannot be null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -180,11 +213,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().FileName = null;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("FileName");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "File name cannot be null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "File name cannot be null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -194,11 +230,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().FileSize = 0;
 
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("FileSize");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "File size cannot be null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "File size cannot be null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
         #endregion
 
@@ -206,9 +245,9 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequest_ThenReceiveSuccessfulResponse()
         {
-            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
 
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
         #endregion
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/FssEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/FssEventDataValidatorTest.cs
@@ -26,7 +26,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BatchId = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchId");
 
             Assert.Multiple(() =>
@@ -43,7 +43,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BusinessUnit = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BusinessUnit");
 
             Assert.Multiple(() =>
@@ -60,7 +60,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.BatchPublishedDate = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchPublishedDate");
 
             Assert.Multiple(() =>
@@ -77,7 +77,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Links");
 
             Assert.Multiple(() =>
@@ -94,7 +94,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchDetails = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchDetails");
 
             Assert.Multiple(() =>
@@ -111,7 +111,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchStatus = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchStatus");
 
             Assert.Multiple(() =>
@@ -128,7 +128,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchDetails.Href = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchDetailsUri");
 
             Assert.Multiple(() =>
@@ -145,7 +145,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Links.BatchStatus.Href = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("BatchStatusUri");
 
             Assert.Multiple(() =>
@@ -162,7 +162,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().Links = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Links");
 
             Assert.Multiple(() =>
@@ -179,7 +179,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().MIMEType = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("MIMEType");
 
             Assert.Multiple(() =>
@@ -196,7 +196,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().Hash = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("Hash");
 
             Assert.Multiple(() =>
@@ -213,7 +213,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().FileName = null;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("FileName");
 
             Assert.Multiple(() =>
@@ -230,7 +230,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeFssEventData.Files.FirstOrDefault().FileSize = 0;
 
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
             result.ShouldHaveValidationErrorFor("FileSize");
 
             Assert.Multiple(() =>
@@ -245,7 +245,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequest_ThenReceiveSuccessfulResponse()
         {
-            var result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
+            TestValidationResult<FssEventData> result = _fssEventDataValidator.TestValidate(_fakeFssEventData);
 
             Assert.That(result.Errors, Is.Empty);
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
@@ -26,7 +26,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.ProductType = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("ProductType");
 
             Assert.Multiple(() =>
@@ -41,7 +41,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.ProductName = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("ProductName");
 
             Assert.Multiple(() =>
@@ -56,7 +56,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.EditionNumber = -1;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("EditionNumber");
 
             Assert.Multiple(() =>
@@ -71,7 +71,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.UpdateNumber = -1;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("UpdateNumber");
 
             Assert.Multiple(() =>
@@ -86,7 +86,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.FileSize = -1;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("FileSize");
 
             Assert.Multiple(() =>
@@ -101,7 +101,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("BoundingBox");
 
             Assert.Multiple(() =>
@@ -120,7 +120,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.NorthLimit = value;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.NorthLimit), 90, result, shouldBeValid);
         }
@@ -134,7 +134,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.SouthLimit = value;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.SouthLimit), 90, result, shouldBeValid);
         }
@@ -148,7 +148,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.EastLimit = value;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.EastLimit), 180, result, shouldBeValid);
         }
@@ -162,7 +162,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.WestLimit = value;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.WestLimit), 180, result, shouldBeValid);
         }
@@ -172,7 +172,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("Status");
 
             Assert.Multiple(() =>
@@ -187,7 +187,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status.StatusDate = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("StatusDate");
 
             Assert.Multiple(() =>
@@ -202,7 +202,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status.StatusName = null;
 
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("StatusName");
 
             Assert.Multiple(() =>
@@ -215,7 +215,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         [Test]
         public void WhenValidRequest_ThenReceiveSuccessfulResponse()
         {
-            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             Assert.That(result.Errors, Is.Empty);
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/Validation/ScsEventDataValidatorTest.cs
@@ -26,11 +26,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.ProductType = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("ProductType");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "ProductType cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "ProductType cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -38,11 +41,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.ProductName = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("ProductName");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "ProductName cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "ProductName cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -50,11 +56,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.EditionNumber = -1;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("EditionNumber");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "EditionNumber cannot be less than zero or blank."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "EditionNumber cannot be less than zero or blank."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -62,11 +71,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.UpdateNumber = -1;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("UpdateNumber");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "UpdateNumber cannot be less than zero or blank."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "UpdateNumber cannot be less than zero or blank."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -74,11 +86,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.FileSize = -1;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("FileSize");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "FileSize cannot be less than zero or blank."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "FileSize cannot be less than zero or blank."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -86,11 +101,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("BoundingBox");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "BoundingBox cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "BoundingBox cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [TestCase(-90.1, false)]
@@ -102,7 +120,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.NorthLimit = value;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.NorthLimit), 90, result, shouldBeValid);
         }
@@ -116,7 +134,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.SouthLimit = value;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.SouthLimit), 90, result, shouldBeValid);
         }
@@ -130,7 +148,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.EastLimit = value;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.EastLimit), 180, result, shouldBeValid);
         }
@@ -144,7 +162,7 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.BoundingBox.WestLimit = value;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
             CheckLatLongResult(nameof(ProductBoundingBox.WestLimit), 180, result, shouldBeValid);
         }
@@ -154,11 +172,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("Status");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "Status cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "Status cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -166,11 +187,14 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status.StatusDate = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("StatusDate");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "StatusDate cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "StatusDate cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
@@ -178,34 +202,43 @@ namespace UKHO.ExternalNotificationService.API.UnitTests.Validation
         {
             _fakeScsEventData.Status.StatusName = null;
 
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
             result.ShouldHaveValidationErrorFor("StatusName");
 
-            Assert.That(result.Errors.Any(x => x.ErrorMessage == "StatusName cannot be blank or null."));
-            Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            Assert.Multiple(() =>
+            {
+                Assert.That(result.Errors.Any(x => x.ErrorMessage == "StatusName cannot be blank or null."));
+                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+            });
         }
 
         [Test]
         public void WhenValidRequest_ThenReceiveSuccessfulResponse()
         {
-            TestValidationResult<ScsEventData> result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
+            var result = _scsEventDataValidator.TestValidate(_fakeScsEventData);
 
-            Assert.That(0, Is.EqualTo(result.Errors.Count));
+            Assert.That(result.Errors, Is.Empty);
         }
 
         private static void CheckLatLongResult(string property, int limit, TestValidationResult<ScsEventData> result, bool shouldBeValid)
         {
             if (shouldBeValid)
             {
-                Assert.That(result.IsValid);
-                Assert.That(0, Is.EqualTo(result.Errors.Count));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.IsValid);
+                    Assert.That(result.Errors, Is.Empty);
+                });
             }
             else
             {
-                Assert.That(1, Is.EqualTo(result.Errors.Count));
+                Assert.That(result.Errors, Has.Count.EqualTo(1));
                 result.ShouldHaveValidationErrorFor(property);
-                Assert.That(result.Errors.Any(x => x.ErrorMessage == $"{property} should be in the range -{limit}.0 to +{limit}.0."));
-                Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+                Assert.Multiple(() =>
+                {
+                    Assert.That(result.Errors.Any(x => x.ErrorMessage == $"{property} should be in the range -{limit}.0 to +{limit}.0."));
+                    Assert.That(result.Errors.Any(x => x.ErrorCode == "OK"));
+                });
             }
         }
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/BaseClass/EventProcessorBaseTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/BaseClass/EventProcessorBaseTest.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Azure.Messaging;
 using FakeItEasy;
+using FakeItEasy.Configuration;
 using NUnit.Framework;
 using UKHO.ExternalNotificationService.Common.BaseClass;
 using UKHO.ExternalNotificationService.Common.Helpers;
@@ -31,9 +32,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.BaseClass
         public void WhenPostFssValidEventRequest_ThenReturnsFssEventData()
         {
             A.CallTo(() => _fakeAzureEventGridDomainService.ConvertObjectTo<FssEventData>(A<object>.Ignored)).Returns(_fssEventData);
-            var data = (object)_fssEventData;
+            object data = (object)_fssEventData;
 
-            var response = _eventProcessorBase.GetEventData<FssEventData>(data);
+            FssEventData response = _eventProcessorBase.GetEventData<FssEventData>(data);
 
             Assert.Multiple(() =>
             {
@@ -45,12 +46,12 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.BaseClass
         [Test]
         public void WhenPostFssValidEventRequest_ThenEventPublishedSuccessfully()
         {
-            var cancellationToken = CancellationToken.None;
-            var cloudEvent = new CloudEvent("test", "test", new object());
+            CancellationToken cancellationToken = CancellationToken.None;
+            CloudEvent cloudEvent = new("test", "test", new object());
 
             A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken));
 
-            var response = _eventProcessorBase.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken);
+            Task response = _eventProcessorBase.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken);
 
             Assert.That(response.IsCompleted);
         }
@@ -64,10 +65,10 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.BaseClass
         [Parallelizable(ParallelScope.All)]
         public async Task WhenPublishEventWithDelayAsync_ThenEventPublishedSuccessfullyWithDelay(int millisecondsDelay)
         {
-            var cancellationToken = CancellationToken.None;
-            var cloudEvent = new CloudEvent("test", "test", new object());
-            var stopwatch = new Stopwatch();
-            var callToPublishEventAsync = A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken));
+            CancellationToken cancellationToken = CancellationToken.None;
+            CloudEvent cloudEvent = new CloudEvent("test", "test", new object());
+            Stopwatch stopwatch = new();
+            IReturnValueArgumentValidationConfiguration<Task> callToPublishEventAsync = A.CallTo(() => _fakeAzureEventGridDomainService.PublishEventAsync(cloudEvent, CorrelationId, cancellationToken));
 
             stopwatch.Start();
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureBlobStorageHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureBlobStorageHealthCheckTest.cs
@@ -36,7 +36,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
@@ -46,7 +46,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy));
 
-            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
@@ -57,7 +57,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Throws(new Exception());
 
-            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureBlobStorageHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureBlobStorageHealthCheckTest.cs
@@ -36,9 +36,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Healthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
 
         [Test]
@@ -46,9 +46,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy));
 
-            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
 
 
@@ -57,9 +57,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureBlobStorageHelper.CheckBlobContainerHealth(A<string>.Ignored, A<string>.Ignored)).Throws(new Exception());
 
-            HealthCheckResult response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureBlobStorageHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureMessageQueueHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureMessageQueueHealthCheckTest.cs
@@ -36,9 +36,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Healthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
 
         [Test]
@@ -46,9 +46,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy));
 
-            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
 
         [Test]
@@ -56,9 +56,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Throws(new Exception());
 
-            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureMessageQueueHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureMessageQueueHealthCheckTest.cs
@@ -36,7 +36,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
@@ -46,7 +46,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy));
 
-            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
@@ -56,7 +56,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureMessageQueueHelper.CheckMessageQueueHealth(A<string>.Ignored, A<string>.Ignored)).Throws(new Exception());
 
-            var response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureMessageQueueHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckServiceTest.cs
@@ -30,7 +30,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
             A.CallTo(() => _fakeAzureWebJobHelper.CheckWebJobsHealth(A<WebJobDetails>.Ignored))
                 .Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy"));
 
-            var response = await _azureWebJobHealthCheckService.CheckHealthAsync();
+            HealthCheckResult response = await _azureWebJobHealthCheckService.CheckHealthAsync();
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
@@ -41,7 +41,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
             A.CallTo(() => _fakeAzureWebJobHelper.CheckWebJobsHealth(A<WebJobDetails>.Ignored))
                 .Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
 
-            var response = await _azureWebJobHealthCheckService.CheckHealthAsync();
+            HealthCheckResult response = await _azureWebJobHealthCheckService.CheckHealthAsync();
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckServiceTest.cs
@@ -12,7 +12,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         private IWebJobAccessKeyProvider _fakeWebJobAccessKeyProvider;
         private IWebHostEnvironment _fakeWebHostEnvironment;
         private IAzureWebJobHelper _fakeAzureWebJobHelper;
-        private IAzureWebJobHealthCheckService _azureWebJobHealthCheckService;
+        private AzureWebJobHealthCheckService _azureWebJobHealthCheckService;
 
         [SetUp]
         public void Setup()
@@ -28,22 +28,22 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         public async Task WhenAzureWebJobStatusIsNotRunning_ThenReturnUnhealthy()
         {
             A.CallTo(() => _fakeAzureWebJobHelper.CheckWebJobsHealth(A<WebJobDetails>.Ignored))
-               .Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy"));
+                .Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy"));
 
-            HealthCheckResult response = await _azureWebJobHealthCheckService.CheckHealthAsync();
+            var response = await _azureWebJobHealthCheckService.CheckHealthAsync();
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
 
         [Test]
         public async Task WhenAzureWebJobStatusIsRunning_ThenReturnHealthy()
         {
             A.CallTo(() => _fakeAzureWebJobHelper.CheckWebJobsHealth(A<WebJobDetails>.Ignored))
-               .Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
+                .Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
 
-            HealthCheckResult response = await _azureWebJobHealthCheckService.CheckHealthAsync();
+            var response = await _azureWebJobHealthCheckService.CheckHealthAsync();
 
-            Assert.That(HealthStatus.Healthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckTest.cs
@@ -29,7 +29,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureWebJobHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
 
-            var response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
@@ -39,7 +39,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureWebJobHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy", new Exception("Azure webjob is unhealthy")));
 
-            var response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/AzureWebJobHealthCheckTest.cs
@@ -29,9 +29,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureWebJobHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy, "Azure webjob is healthy"));
 
-            HealthCheckResult response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Healthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
 
         [Test]
@@ -39,9 +39,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeAzureWebJobHealthCheckService.CheckHealthAsync(A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Azure webjob is unhealthy", new Exception("Azure webjob is unhealthy")));
 
-            HealthCheckResult response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _azureWebJobHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/EventHubLoggingHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/EventHubLoggingHealthCheckTest.cs
@@ -30,7 +30,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeEventHubLoggingHealthClient.CheckHealthAsync(A<HealthCheckContext>.Ignored, A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            var response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
@@ -40,7 +40,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeEventHubLoggingHealthClient.CheckHealthAsync(A<HealthCheckContext>.Ignored, A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Event hub is unhealthy", new Exception("Event hub is unhealthy")));
 
-            var response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            HealthCheckResult response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
             Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/EventHubLoggingHealthCheckTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/EventHubLoggingHealthCheckTest.cs
@@ -30,9 +30,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeEventHubLoggingHealthClient.CheckHealthAsync(A<HealthCheckContext>.Ignored, A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Healthy));
 
-            HealthCheckResult response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Healthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Healthy));
         }
 
         [Test]
@@ -40,9 +40,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         {
             A.CallTo(() => _fakeEventHubLoggingHealthClient.CheckHealthAsync(A<HealthCheckContext>.Ignored, A<CancellationToken>.Ignored)).Returns(new HealthCheckResult(HealthStatus.Unhealthy, "Event hub is unhealthy", new Exception("Event hub is unhealthy")));
 
-            HealthCheckResult response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
+            var response = await _eventHubLoggingHealthCheck.CheckHealthAsync(new HealthCheckContext());
 
-            Assert.That(HealthStatus.Unhealthy, Is.EqualTo(response.Status));
+            Assert.That(response.Status, Is.EqualTo(HealthStatus.Unhealthy));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/WebJobsAccessKeyProviderTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/WebJobsAccessKeyProviderTest.cs
@@ -28,15 +28,15 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         [Test]
         public void GetWebJobAccessKey_ReturnsCorrectKeyWhenExists()
         {
-            string webJobsAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("webjob1key");
-            string expectedAccessKey = _configuration.GetValue<string>("webjob1key");
-            Assert.That(expectedAccessKey, Is.EqualTo(webJobsAccessKey));
+            var actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("webjob1key");
+            var expectedAccessKey = _configuration.GetValue<string>("webjob1key");
+            Assert.That(actualAccessKey, Is.EqualTo(expectedAccessKey));
         }
 
         [Test]
         public void GetWebJobAccessKey_ReturnsNullWhenNotExists()
         {
-            string actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("nonexistingkey");
+            var actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("nonexistingkey");
             Assert.That(actualAccessKey, Is.Null);
         }
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/WebJobsAccessKeyProviderTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/HealthCheck/WebJobsAccessKeyProviderTest.cs
@@ -28,15 +28,15 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.HealthCheck
         [Test]
         public void GetWebJobAccessKey_ReturnsCorrectKeyWhenExists()
         {
-            var actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("webjob1key");
-            var expectedAccessKey = _configuration.GetValue<string>("webjob1key");
+            string actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("webjob1key");
+            string expectedAccessKey = _configuration.GetValue<string>("webjob1key");
             Assert.That(actualAccessKey, Is.EqualTo(expectedAccessKey));
         }
 
         [Test]
         public void GetWebJobAccessKey_ReturnsNullWhenNotExists()
         {
-            var actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("nonexistingkey");
+            string actualAccessKey = _webJobsAccessKeyProvider.GetWebJobsAccessKey("nonexistingkey");
             Assert.That(actualAccessKey, Is.Null);
         }
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Helpers/EventSubscriptionConfigurationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Helpers/EventSubscriptionConfigurationTest.cs
@@ -40,7 +40,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Helpers
         [Test]
         public void WhenCallSetEventSubscription_ThenReturnEventSubscription()
         {
-            var subscriptionRequestMessage = new SubscriptionRequestMessage
+            SubscriptionRequestMessage subscriptionRequestMessage = new()
             {
                 CorrelationId = Guid.NewGuid().ToString(),
                 D365CorrelationId = Guid.NewGuid().ToString(),
@@ -51,7 +51,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Helpers
                 WebhookUrl = WebhookUrl
             };
 
-            var result = _eventSubscriptionConfiguration.SetEventSubscription(subscriptionRequestMessage);
+            EventGridSubscriptionData result = _eventSubscriptionConfiguration.SetEventSubscription(subscriptionRequestMessage);
             Assert.That(result, Is.Not.Null);
             Assert.That(result, Is.InstanceOf<EventGridSubscriptionData>());
             Assert.Multiple(() =>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Repository/NotificationRepositoryTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Repository/NotificationRepositoryTest.cs
@@ -29,7 +29,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Repository
         [Test]
         public void WhenPostValidNotificationTypes_ThenReturnsNotificationTypeInResponse()
         {
-            var notificationType = _notificationRepository.GetAllNotificationTypes().FirstOrDefault(x => x.Name == "Data test");
+            NotificationType notificationType = _notificationRepository.GetAllNotificationTypes().FirstOrDefault(x => x.Name == "Data test");
 
             Assert.That(notificationType.Name, Is.EqualTo(_fakeNotificationType.FirstOrDefault(x => x.Name == "Data test").Name));
         }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Repository/NotificationRepositoryTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Repository/NotificationRepositoryTest.cs
@@ -18,7 +18,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Repository
         [SetUp]
         public void Setup()
         {
-            _fakeNotificationType = new List<NotificationType>() { new NotificationType() { Name = "Data test", TopicName = "test" } };
+            _fakeNotificationType = [new() { Name = "Data test", TopicName = "test" }];
 
             _fakeEnsConfiguration = A.Fake<IOptions<EnsConfiguration>>();
             _fakeEnsConfiguration.Value.NotificationTypes = _fakeNotificationType;
@@ -29,9 +29,9 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Repository
         [Test]
         public void WhenPostValidNotificationTypes_ThenReturnsNotificationTypeInResponse()
         {
-            NotificationType notificationType = _notificationRepository.GetAllNotificationTypes().FirstOrDefault(x => x.Name == "Data test");
+            var notificationType = _notificationRepository.GetAllNotificationTypes().FirstOrDefault(x => x.Name == "Data test");
 
-            Assert.That(_fakeNotificationType.FirstOrDefault(x => x.Name == "Data test").Name, Is.EqualTo(notificationType.Name));
+            Assert.That(notificationType.Name, Is.EqualTo(_fakeNotificationType.FirstOrDefault(x => x.Name == "Data test").Name));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Storage/StorageServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Storage/StorageServiceTest.cs
@@ -37,7 +37,7 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Storage
         public void WhenValidStorageConfiguration_ThenValidStorageAccountConnectionStringRequest()
         {
             _fakeSubscriptionStorageConfiguration.Value.StorageAccountKey = "Test";
-            var response = _storageService.GetStorageAccountConnectionString();
+            string response = _storageService.GetStorageAccountConnectionString();
 
             Assert.That(response, Is.Not.Null);
             Assert.That(response, Is.EqualTo("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=Test;EndpointSuffix=core.windows.net"));

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Storage/StorageServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/Storage/StorageServiceTest.cs
@@ -26,7 +26,6 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Storage
             _storageService = new StorageService(_fakeSubscriptionStorageConfiguration);
         }
 
-
         [Test]
         public void WhenInValidStorageConfiguration_ThenKeyNotFoundException()
         {
@@ -38,10 +37,10 @@ namespace UKHO.ExternalNotificationService.Common.UnitTests.Storage
         public void WhenValidStorageConfiguration_ThenValidStorageAccountConnectionStringRequest()
         {
             _fakeSubscriptionStorageConfiguration.Value.StorageAccountKey = "Test";
-            string response = _storageService.GetStorageAccountConnectionString();
+            var response = _storageService.GetStorageAccountConnectionString();
 
             Assert.That(response, Is.Not.Null);
-            Assert.That("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=Test;EndpointSuffix=core.windows.net", Is.EqualTo(response));
+            Assert.That(response, Is.EqualTo("DefaultEndpointsProtocol=https;AccountName=test;AccountKey=Test;EndpointSuffix=core.windows.net"));
         }
     }
 }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
@@ -19,7 +19,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Helpers/CommonHelperTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Helpers/CommonHelperTest.cs
@@ -38,9 +38,9 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Helpers
                 .AddPolicyHandler(CommonHelper.GetRetryPolicy(_fakeLogger, _retryCount, SleepDuration))
                 .AddHttpMessageHandler(() => new ServiceUnavailableDelegatingHandler());
 
-            var configuredClient = CreateClient(services);
+            HttpClient configuredClient = CreateClient(services);
 
-            var result = await configuredClient.GetAsync("https://testretry.com");
+            HttpResponseMessage result = await configuredClient.GetAsync("https://testretry.com");
 
             Assert.Multiple(() =>
             {
@@ -60,9 +60,9 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Helpers
                 .AddPolicyHandler(CommonHelper.GetRetryPolicy(_fakeLogger, _retryCount, SleepDuration))
                 .AddHttpMessageHandler(() => new InternalServerDelegatingHandler());
 
-            var configuredClient = CreateClient(services);
+            HttpClient configuredClient = CreateClient(services);
 
-            var result = await configuredClient.GetAsync("https://testretry.com");
+            HttpResponseMessage result = await configuredClient.GetAsync("https://testretry.com");
 
             Assert.Multiple(() =>
             {
@@ -74,22 +74,22 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Helpers
         [Test]
         public void WhenValidGetExternalNotificationEntityEventThenReturnSuccessResponse()
         {
-            var subscriptionRequestResult = GetSubscriptionSuccessRequestResult();
+            SubscriptionRequestResult subscriptionRequestResult = GetSubscriptionSuccessRequestResult();
             const bool isActive = true;
             const int successStatusCode = 1000001;
 
-            var response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, successStatusCode);
+            ExternalNotificationEntity response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, successStatusCode);
             Assert.That(response, Is.Not.Null);
         }
 
         [Test]
         public void WhenInvalidGetExternalNotificationEntityEventThenReturnFailResponse()
         {
-            var subscriptionRequestResult = GetSubscriptionFailureRequestResult();
+            SubscriptionRequestResult subscriptionRequestResult = GetSubscriptionFailureRequestResult();
             const bool isActive = false;
             const int failureStatusCode = 1000002;
 
-            var response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, failureStatusCode);
+            ExternalNotificationEntity response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, failureStatusCode);
             Assert.That(response, Is.Not.Null);
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Helpers/CommonHelperTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Helpers/CommonHelperTest.cs
@@ -38,12 +38,15 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Helpers
                 .AddPolicyHandler(CommonHelper.GetRetryPolicy(_fakeLogger, _retryCount, SleepDuration))
                 .AddHttpMessageHandler(() => new ServiceUnavailableDelegatingHandler());
 
-            HttpClient configuredClient = CreateClient(services);
+            var configuredClient = CreateClient(services);
 
-            HttpResponseMessage result = await configuredClient.GetAsync("https://testretry.com");
+            var result = await configuredClient.GetAsync("https://testretry.com");
 
-            Assert.That(_isRetryCalled, Is.False);
-            Assert.That(HttpStatusCode.ServiceUnavailable, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_isRetryCalled, Is.False);
+                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.ServiceUnavailable));
+            });
         }
 
         [Test]
@@ -57,31 +60,36 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Helpers
                 .AddPolicyHandler(CommonHelper.GetRetryPolicy(_fakeLogger, _retryCount, SleepDuration))
                 .AddHttpMessageHandler(() => new InternalServerDelegatingHandler());
 
-            HttpClient configuredClient = CreateClient(services);
+            var configuredClient = CreateClient(services);
 
-            HttpResponseMessage result = await configuredClient.GetAsync("https://testretry.com");
+            var result = await configuredClient.GetAsync("https://testretry.com");
 
-            Assert.That(_isRetryCalled, Is.False);
-            Assert.That(HttpStatusCode.InternalServerError, Is.EqualTo(result.StatusCode));
+            Assert.Multiple(() =>
+            {
+                Assert.That(_isRetryCalled, Is.False);
+                Assert.That(result.StatusCode, Is.EqualTo(HttpStatusCode.InternalServerError));
+            });
         }
 
         [Test]
         public void WhenValidGetExternalNotificationEntityEventThenReturnSuccessResponse()
         {
-            SubscriptionRequestResult subscriptionRequestResult = GetSubscriptionSuccessRequestResult();
+            var subscriptionRequestResult = GetSubscriptionSuccessRequestResult();
             const bool isActive = true;
             const int successStatusCode = 1000001;
-            ExternalNotificationEntity response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, successStatusCode);
+
+            var response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, successStatusCode);
             Assert.That(response, Is.Not.Null);
         }
 
         [Test]
         public void WhenInvalidGetExternalNotificationEntityEventThenReturnFailResponse()
         {
-            SubscriptionRequestResult subscriptionRequestResult = GetSubscriptionFailureRequestResult();
+            var subscriptionRequestResult = GetSubscriptionFailureRequestResult();
             const bool isActive = false;
             const int failureStatusCode = 1000002;
-            ExternalNotificationEntity response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, failureStatusCode);
+
+            var response = CommonHelper.GetExternalNotificationEntity(subscriptionRequestResult, isActive, failureStatusCode);
             Assert.That(response, Is.Not.Null);
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/CallbackServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/CallbackServiceTest.cs
@@ -41,7 +41,7 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         {
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(string.Empty);
 
-            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
@@ -52,11 +52,11 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenInvalidCallbackToD365UsingDataverseRequest_ThenReturnsBadRequest()
         {
-            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
+            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
             A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
@@ -67,13 +67,13 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenValidCallbackToD365UsingDataverseRequest_ThenReturnsNoContent()
         {
-            var getExternalNotificationEntry = GetExternalNotificationEntity();
-            var jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
-            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
+            ExternalNotificationEntity getExternalNotificationEntry = GetExternalNotificationEntity();
+            string jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
+            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
             A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
@@ -86,7 +86,7 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         {
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(string.Empty);
 
-            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
@@ -97,11 +97,11 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenInvalidDeadLetterCallbackToD365UsingDataverseRequest_ThenReturnsBadRequest()
         {
-            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
+            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
             A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
@@ -112,13 +112,13 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenValidDeadLetterCallbackToD365UsingDataverseRequest_ThenReturnsNoContent()
         {
-            var getExternalNotificationEntry = GetExternalNotificationEntity();
-            var jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
-            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
+            ExternalNotificationEntity getExternalNotificationEntry = GetExternalNotificationEntity();
+            string jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
+            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
             A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
+            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
             Assert.Multiple(() =>
             {
                 Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/CallbackServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/CallbackServiceTest.cs
@@ -21,9 +21,10 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         private IAuthTokenProvider _fakeAuthTokenProvider;
         private ILogger<CallbackService> _fakeLogger;
         private ICallbackClient _fakeCallbackClient;
-        private ICallbackService _callbackService;
+        private CallbackService _callbackService;
 
         private const string FakeExternalEntityPath = "ukho_externalnotifications(1ea01f10-1372-13fb-13a1-1300f3a3faaa)";
+        private const string FakeAccessToken = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IHNlcnZlciIsImlhdCI6MTU1ODMyOTg2MCwiZXhwIjoxNTg5OTUyMjYwLCJhdWQiOiJ3d3cudGVzdC5jb20iLCJzdWIiOiJ0ZXN0dXNlckB0ZXN0LmNvbSIsIm9pZCI6IjE0Y2I3N2RjLTFiYTUtNDcxZC1hY2Y1LWEwNDBkMTM4YmFhOSJ9.uOPTbf2Tg6M2OIC6bPHsBAOUuFIuCIzQL_MV3qV6agc";
 
         [SetUp]
         public void Setup()
@@ -40,42 +41,44 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         {
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(string.Empty);
 
-            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.Unauthorized, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode, Is.False);
+            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+                Assert.That(response.IsSuccessStatusCode, Is.False);
+            });
         }
 
         [Test]
         public async Task WhenInvalidCallbackToD365UsingDataverseRequest_ThenReturnsBadRequest()
         {
-            string fakeAccessToken = GetFakeToken();
+            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
+            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
+            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
-            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(fakeAccessToken);
-            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
-             .Returns(httpResponse);
-
-            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode, Is.False);
+            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+                Assert.That(response.IsSuccessStatusCode, Is.False);
+            });
         }
 
         [Test]
         public async Task WhenValidCallbackToD365UsingDataverseRequest_ThenReturnsNoContent()
         {
-            string fakeAccessToken = GetFakeToken();
+            var getExternalNotificationEntry = GetExternalNotificationEntity();
+            var jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
+            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
+            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
+            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            ExternalNotificationEntity getExternalNotificationEntry = GetExternalNotificationEntity();
-            string jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
-            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage() { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
-
-            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(fakeAccessToken);
-            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
-             .Returns(httpResponse);
-
-            HttpResponseMessage response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.NoContent, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode);
+            var response = await _callbackService.CallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+                Assert.That(response.IsSuccessStatusCode);
+            });
         }
 
         [Test]
@@ -83,48 +86,44 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         {
             A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(string.Empty);
 
-            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.Unauthorized, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode, Is.False);
+            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.Unauthorized));
+                Assert.That(response.IsSuccessStatusCode, Is.False);
+            });
         }
 
         [Test]
         public async Task WhenInvalidDeadLetterCallbackToD365UsingDataverseRequest_ThenReturnsBadRequest()
         {
-            string fakeAccessToken = GetFakeToken();
+            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
+            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
+            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.BadRequest, RequestMessage = new HttpRequestMessage() { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes("Bad Request"))) };
-            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(fakeAccessToken);
-            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
-             .Returns(httpResponse);
-
-            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.BadRequest, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode, Is.False);
+            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, GetExternalNotificationEntity(), GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
+                Assert.That(response.IsSuccessStatusCode, Is.False);
+            });
         }
 
         [Test]
         public async Task WhenValidDeadLetterCallbackToD365UsingDataverseRequest_ThenReturnsNoContent()
         {
-            string fakeAccessToken = GetFakeToken();
+            var getExternalNotificationEntry = GetExternalNotificationEntity();
+            var jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
+            var httpResponse = new HttpResponseMessage { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
+            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(FakeAccessToken);
+            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored)).Returns(httpResponse);
 
-            ExternalNotificationEntity getExternalNotificationEntry = GetExternalNotificationEntity();
-            string jsonString = JsonSerializer.Serialize(getExternalNotificationEntry);
-            var httpResponse = new HttpResponseMessage() { StatusCode = HttpStatusCode.NoContent, RequestMessage = new HttpRequestMessage() { Method = HttpMethod.Patch, RequestUri = new Uri("http://test.com") }, Content = new StreamContent(new MemoryStream(Encoding.UTF8.GetBytes(jsonString))) };
-
-            A.CallTo(() => _fakeAuthTokenProvider.GetADAccessToken(A<SubscriptionRequestMessage>.Ignored)).Returns(fakeAccessToken);
-            A.CallTo(() => _fakeCallbackClient.GetCallbackD365Client(A<string>.Ignored, A<string>.Ignored, A<object>.Ignored, A<string>.Ignored, A<CancellationToken>.Ignored))
-             .Returns(httpResponse);
-
-            HttpResponseMessage response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
-            Assert.That(HttpStatusCode.NoContent, Is.EqualTo(response.StatusCode));
-            Assert.That(response.IsSuccessStatusCode);
-        }
-
-
-        private static string GetFakeToken()
-        {
-            return "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJ0ZXN0IHNlcnZlciIsImlhdCI6MTU1ODMyOTg2MCwiZXhwIjoxNTg5OTUyMjYwLCJhdWQiOiJ3d3cudGVzdC5jb20iLCJzdWIiOiJ0ZXN0dXNlckB0ZXN0LmNvbSIsIm9pZCI6IjE0Y2I3N2RjLTFiYTUtNDcxZC1hY2Y1LWEwNDBkMTM4YmFhOSJ9.uOPTbf2Tg6M2OIC6bPHsBAOUuFIuCIzQL_MV3qV6agc";
+            var response = await _callbackService.DeadLetterCallbackToD365UsingDataverse(FakeExternalEntityPath, getExternalNotificationEntry, GetSubscriptionRequestMessage());
+            Assert.Multiple(() =>
+            {
+                Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+                Assert.That(response.IsSuccessStatusCode);
+            });
         }
 
         private static ExternalNotificationEntity GetExternalNotificationEntity()

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/HandleDeadLetterServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/HandleDeadLetterServiceTest.cs
@@ -1,4 +1,5 @@
 ﻿using System.Net.Http;
+using System.Threading.Tasks;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -32,7 +33,8 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
             _fakeEnsStorageConfiguration = A.Fake<IOptions<SubscriptionStorageConfiguration>>();
             _fakeD365CallbackConfiguration = A.Fake<IOptions<D365CallbackConfiguration>>();
 
-            _handleDeadLetterService = new HandleDeadLetterService(_fakeCallbackService, _fakeAzureMessageQueueHelper, _fakeEnsStorageConfiguration, _fakeLogger, _fakeD365CallbackConfiguration);
+            _handleDeadLetterService = new HandleDeadLetterService(_fakeCallbackService, _fakeAzureMessageQueueHelper, _fakeEnsStorageConfiguration,
+                                                                   _fakeLogger, _fakeD365CallbackConfiguration);
         }
 
         [Test]
@@ -42,7 +44,7 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
 
             A.CallTo(() => _fakeCallbackService.CallbackToD365UsingDataverse(A<string>.Ignored, A<object>.Ignored, A<SubscriptionRequestMessage>.Ignored)).Returns(new HttpResponseMessage());
 
-            var response = _handleDeadLetterService.ProcessDeadLetter(FilePath, subscriptionId, new SubscriptionRequestMessage(), FileName);
+            Task response = _handleDeadLetterService.ProcessDeadLetter(FilePath, subscriptionId, new SubscriptionRequestMessage(), FileName);
 
             A.CallTo(() => _fakeAzureMessageQueueHelper.CopyDeadLetterBlob(A<SubscriptionStorageConfiguration>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/HandleDeadLetterServiceTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/HandleDeadLetterServiceTest.cs
@@ -1,5 +1,4 @@
 ﻿using System.Net.Http;
-using System.Threading.Tasks;
 using FakeItEasy;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
@@ -33,8 +32,7 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
             _fakeEnsStorageConfiguration = A.Fake<IOptions<SubscriptionStorageConfiguration>>();
             _fakeD365CallbackConfiguration = A.Fake<IOptions<D365CallbackConfiguration>>();
 
-            _handleDeadLetterService = new HandleDeadLetterService(_fakeCallbackService, _fakeAzureMessageQueueHelper, _fakeEnsStorageConfiguration,
-                                                                   _fakeLogger, _fakeD365CallbackConfiguration);
+            _handleDeadLetterService = new HandleDeadLetterService(_fakeCallbackService, _fakeAzureMessageQueueHelper, _fakeEnsStorageConfiguration, _fakeLogger, _fakeD365CallbackConfiguration);
         }
 
         [Test]
@@ -44,7 +42,7 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
 
             A.CallTo(() => _fakeCallbackService.CallbackToD365UsingDataverse(A<string>.Ignored, A<object>.Ignored, A<SubscriptionRequestMessage>.Ignored)).Returns(new HttpResponseMessage());
 
-            Task response = _handleDeadLetterService.ProcessDeadLetter(FilePath, subscriptionId, new SubscriptionRequestMessage(), FileName);
+            var response = _handleDeadLetterService.ProcessDeadLetter(FilePath, subscriptionId, new SubscriptionRequestMessage(), FileName);
 
             A.CallTo(() => _fakeAzureMessageQueueHelper.CopyDeadLetterBlob(A<SubscriptionStorageConfiguration>.Ignored, A<string>.Ignored)).MustHaveHappenedOnceExactly();
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/SubscriptionServiceDataTests.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/SubscriptionServiceDataTests.cs
@@ -29,10 +29,10 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenCreateOrUpdateSubscriptionThenCreateSubscription()
         {
-            var cancellationToken = CancellationToken.None;
-            var subscriptionRequestMessage = GetSubscriptionRequestMessage();
+            CancellationToken cancellationToken = CancellationToken.None;
+            SubscriptionRequestMessage subscriptionRequestMessage = GetSubscriptionRequestMessage();
 
-            var response = await _subscriptionServiceData.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken);
+            DomainTopicEventSubscriptionResource response = await _subscriptionServiceData.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken);
 
             A.CallTo(() => _fakeAzureEventGridDomainService.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken)).MustHaveHappenedOnceExactly();
             Assert.That(response, Is.InstanceOf<DomainTopicEventSubscriptionResource>());
@@ -41,8 +41,8 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenDeleteSubscriptionEventCalledThenDeleteSubscription()
         {
-            var cancellationToken = CancellationToken.None;
-            var subscriptionRequestMessage = GetSubscriptionRequestMessage();
+            CancellationToken cancellationToken = CancellationToken.None;
+            SubscriptionRequestMessage subscriptionRequestMessage = GetSubscriptionRequestMessage();
 
             await _subscriptionServiceData.DeleteSubscription(subscriptionRequestMessage, cancellationToken);
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/SubscriptionServiceDataTests.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/Services/SubscriptionServiceDataTests.cs
@@ -29,10 +29,10 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenCreateOrUpdateSubscriptionThenCreateSubscription()
         {
-            CancellationToken cancellationToken = CancellationToken.None;
-            SubscriptionRequestMessage subscriptionRequestMessage = GetSubscriptionRequestMessage();
+            var cancellationToken = CancellationToken.None;
+            var subscriptionRequestMessage = GetSubscriptionRequestMessage();
 
-            DomainTopicEventSubscriptionResource response = await _subscriptionServiceData.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken);
+            var response = await _subscriptionServiceData.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken);
 
             A.CallTo(() => _fakeAzureEventGridDomainService.CreateOrUpdateSubscription(subscriptionRequestMessage, cancellationToken)).MustHaveHappenedOnceExactly();
             Assert.That(response, Is.InstanceOf<DomainTopicEventSubscriptionResource>());
@@ -41,8 +41,8 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
         [Test]
         public async Task WhenDeleteSubscriptionEventCalledThenDeleteSubscription()
         {
-            CancellationToken cancellationToken = CancellationToken.None;
-            SubscriptionRequestMessage subscriptionRequestMessage = GetSubscriptionRequestMessage();
+            var cancellationToken = CancellationToken.None;
+            var subscriptionRequestMessage = GetSubscriptionRequestMessage();
 
             await _subscriptionServiceData.DeleteSubscription(subscriptionRequestMessage, cancellationToken);
 
@@ -59,7 +59,6 @@ namespace UKHO.ExternalNotificationService.Webjob.UnitTests.Services
                 NotificationTypeTopicName = "test-Topic-type",
                 SubscriptionId = "246d71e7-1475-ec11-8943-002248818222",
                 WebhookUrl = "https://testurl.com"
-
             };
         }
     }

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
@@ -16,6 +16,10 @@
     <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="8.0.13" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.6.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
@@ -20,7 +20,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="NUnit3TestAdapter" Version="4.6.0">
+    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
#### PR Classification
Code cleanup and modernization of NUnit test assertions.

#### PR Summary
This pull request updates various test files to improve readability and consistency by adopting modern NUnit assertion styles. Key changes include:
- `ExpirationListTests.cs`: Replaced `CollectionAssert` with `Assert.That` for improved readability.
- `Message.cs`: Refactored the `Data` property for concise initialization.
- `UKHO.D365CallbackDistributorStub.API.Tests.csproj`: Updated NUnit test adapter to `NUnit.Analyzers`.
- `D365HttpPayloadValidationTest.cs`: Added `[TestFixture]` attribute and updated assertions to `Assert.That`.
- Multiple test files: Implemented `Assert.Multiple` for grouping assertions, enhancing clarity across tests.
