### PR TITLE
Feature/abzu 266548 notifications for senc bu

### DIFF
--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/D365PayloadTestData/D365FssSencSamplePayload.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/D365PayloadTestData/D365FssSencSamplePayload.json
@@ -1,0 +1,354 @@
+{
+    "BusinessUnitId": "b51c611d-e6bb-e211-8cfd-984be17c38f7",
+    "CorrelationId": "6ea03f10-2672-46fb-92a1-5200f6a4fedc",
+    "Depth": 1,
+    "InitiatingUserAzureActiveDirectoryObjectId": "349b02df-fca1-4a40-bddf-277d294fb307",
+    "InitiatingUserId": "2937697b-81b9-e211-a1a0-984be17c9a93",
+    "InputParameters": [
+        {
+            "key": "Target",
+            "value": {
+                "__type": "Entity:http://schemas.microsoft.com/xrm/2011/Contracts",
+                "Attributes": [
+                    {
+                        "key": "modifiedby",
+                        "value": {
+                            "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Id": "2937697b-81b9-e211-a1a0-984be17c9a93",
+                            "KeyAttributes": [],
+                            "LogicalName": "systemuser",
+                            "Name": null,
+                            "RowVersion": null
+                        }
+                    },
+                    {
+                        "key": "statecode",
+                        "value": {
+                            "__type": "OptionSetValue:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Value": 0
+                        }
+                    },
+                    {
+                        "key": "modifiedon",
+                        "value": "/Date(1642158297000)/"
+                    },
+                    {
+                        "key": "createdon",
+                        "value": "/Date(1642158297000)/"
+                    },
+                    {
+                        "key": "ukho_regardingcase",
+                        "value": {
+                            "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Id": "0a062a97-205c-ec11-8f8f-000d3a28ef73",
+                            "KeyAttributes": [],
+                            "LogicalName": "incident",
+                            "Name": null,
+                            "RowVersion": null
+                        }
+                    },
+                    {
+                        "key": "ukho_distributorapplicationname",
+                        "value": "testapp"
+                    },
+                    {
+                        "key": "statuscode",
+                        "value": {
+                            "__type": "OptionSetValue:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Value": 1
+                        }
+                    },
+                    {
+                        "key": "modifiedonbehalfby",
+                        "value": null
+                    },
+                    {
+                        "key": "ukho_subscriptiontype",
+                        "value": {
+                            "__type": "OptionSetValue:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Value": 832930001
+                        }
+                    },
+                    {
+                        "key": "ukho_webhookurl",
+                        "value": "https://ens-dev-webapp-stub.azurewebsites.net/webhook/notification"
+                    },
+                    {
+                        "key": "ukho_externalnotificationid",
+                        "value": "bd0ccbc8-2975-ec11-8943-002248818243"
+                    },
+                    {
+                        "key": "ukho_subscribedaccount",
+                        "value": {
+                            "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Id": "75da2302-6d56-ec11-8f8f-002248810f88",
+                            "KeyAttributes": [],
+                            "LogicalName": "account",
+                            "Name": null,
+                            "RowVersion": null
+                        }
+                    },
+                    {
+                        "key": "organizationid",
+                        "value": {
+                            "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Id": "018c5751-d0f6-4a8c-96b5-156d02da602c",
+                            "KeyAttributes": [],
+                            "LogicalName": "organization",
+                            "Name": null,
+                            "RowVersion": null
+                        }
+                    },
+                    {
+                        "key": "ukho_subscriptionstate",
+                        "value": false
+                    },
+                    {
+                        "key": "createdby",
+                        "value": {
+                            "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                            "Id": "2937697b-81b9-e211-a1a0-984be17c9a93",
+                            "KeyAttributes": [],
+                            "LogicalName": "systemuser",
+                            "Name": null,
+                            "RowVersion": null
+                        }
+                    }
+                ],
+                "EntityState": null,
+                "FormattedValues": [
+                    {
+                        "key": "statecode",
+                        "value": "Active"
+                    },
+                    {
+                        "key": "modifiedon",
+                        "value": "2022-01-14T11:04:57-00:00"
+                    },
+                    {
+                        "key": "createdon",
+                        "value": "2022-01-14T11:04:57-00:00"
+                    },
+                    {
+                        "key": "statuscode",
+                        "value": "Active"
+                    },
+                  {
+                    "key": "ukho_subscriptiontype",
+                    "value": "File Share Service - SENC"
+                  },
+                    {
+                        "key": "ukho_subscriptionstate",
+                        "value": "Test"
+                    }
+                ],
+                "Id": "bd0ccbc8-2975-ec11-8943-002248818243",
+                "KeyAttributes": [],
+                "LogicalName": "ukho_externalnotification",
+                "RelatedEntities": [],
+                "RowVersion": null
+            }
+        }
+    ],
+    "IsExecutingOffline": false,
+    "IsInTransaction": false,
+    "IsOfflinePlayback": false,
+    "IsolationMode": 1,
+    "MessageName": "Create",
+    "Mode": 1,
+    "OperationCreatedOn": "/Date(1642158297000+0000)/",
+    "OperationId": "77b6c5ce-2975-ec11-8943-002248818233",
+    "OrganizationId": "018c5751-d0f6-4a8c-96b5-156d02da602c",
+    "OrganizationName": "org87a169ba",
+    "OutputParameters": [
+        {
+            "key": "id",
+            "value": "bd0ccbc8-2975-ec11-8943-002248818243"
+        }
+    ],
+    "OwningExtension": {
+        "Id": "7c8c3266-9d59-ec11-8f8f-002248810556",
+        "KeyAttributes": [],
+        "LogicalName": "sdkmessageprocessingstep",
+        "Name": null,
+        "RowVersion": null
+    },
+    "ParentContext": {
+        "BusinessUnitId": "b51c611d-e6bb-e211-8cfd-984be17c38f7",
+        "CorrelationId": "6ea03f10-2672-46fb-92a1-5200f6a4fedc",
+        "Depth": 1,
+        "InitiatingUserAzureActiveDirectoryObjectId": "349b02df-fca1-4a40-bddf-277d294fb307",
+        "InitiatingUserId": "2937697b-81b9-e211-a1a0-984be17c9a93",
+        "InputParameters": [
+            {
+                "key": "Target",
+                "value": {
+                    "__type": "Entity:http://schemas.microsoft.com/xrm/2011/Contracts",
+                    "Attributes": [
+                        {
+                            "key": "ukho_webhookurl",
+                            "value": "https://ens-dev-webapp-stub.azurewebsites.net/webhook/notification"
+                        },
+                        {
+                            "key": "ukho_distributorapplicationname",
+                            "value": "testapp"
+                        },
+                        {
+                            "key": "ukho_subscriptiontype",
+                            "value": {
+                                "__type": "OptionSetValue:http://schemas.microsoft.com/xrm/2011/Contracts",
+                                "Value": 832930001
+                            }
+                        },
+                        {
+                            "key": "ukho_subscriptionstate",
+                            "value": false
+                        },
+                        {
+                            "key": "statuscode",
+                            "value": {
+                                "__type": "OptionSetValue:http://schemas.microsoft.com/xrm/2011/Contracts",
+                                "Value": 1
+                            }
+                        },
+                        {
+                            "key": "ukho_externalnotificationid",
+                            "value": "bd0ccbc8-2975-ec11-8943-002248818243"
+                        },
+                        {
+                            "key": "ukho_regardingcase",
+                            "value": {
+                                "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                                "Id": "0a062a97-205c-ec11-8f8f-000d3a28ef73",
+                                "KeyAttributes": [],
+                                "LogicalName": "incident",
+                                "Name": null,
+                                "RowVersion": null
+                            }
+                        },
+                        {
+                            "key": "ukho_subscribedaccount",
+                            "value": {
+                                "__type": "EntityReference:http://schemas.microsoft.com/xrm/2011/Contracts",
+                                "Id": "75da2302-6d56-ec11-8f8f-002248810f88",
+                                "KeyAttributes": [],
+                                "LogicalName": "account",
+                                "Name": null,
+                                "RowVersion": null
+                            }
+                        }
+                    ],
+                    "EntityState": null,
+                    "FormattedValues": [],
+                    "Id": "bd0ccbc8-2975-ec11-8943-002248818243",
+                    "KeyAttributes": [],
+                    "LogicalName": "ukho_externalnotification",
+                    "RelatedEntities": [],
+                    "RowVersion": null
+                }
+            },
+            {
+                "key": "x-ms-app-name",
+                "value": "cr519_SMEHub"
+            },
+            {
+                "key": "SuppressDuplicateDetection",
+                "value": false
+            }
+        ],
+        "IsExecutingOffline": false,
+        "IsInTransaction": false,
+        "IsOfflinePlayback": false,
+        "IsolationMode": 1,
+        "MessageName": "Create",
+        "Mode": 1,
+        "OperationCreatedOn": "/Date(1642158297000+0000)/",
+        "OperationId": "77b6c5ce-2975-ec11-8943-002248818233",
+        "OrganizationId": "018c5751-d0f6-4a8c-96b5-156d02da602c",
+        "OrganizationName": "org87a169ba",
+        "OutputParameters": [],
+        "OwningExtension": {
+            "Id": "7c8c3266-9d59-ec11-8f8f-002248810556",
+            "KeyAttributes": [],
+            "LogicalName": "sdkmessageprocessingstep",
+            "Name": null,
+            "RowVersion": null
+        },
+        "ParentContext": null,
+        "PostEntityImages": [],
+        "PreEntityImages": [],
+        "PrimaryEntityId": "bd0ccbc8-2975-ec11-8943-002248818243",
+        "PrimaryEntityName": "ukho_externalnotification",
+        "RequestId": "004af0c9-73a5-4420-9bf9-b6b50f82e3cc",
+        "SecondaryEntityName": "none",
+        "SharedVariables": [
+            {
+                "key": "IsAutoTransact",
+                "value": true
+            },
+            {
+                "key": "x-ms-app-name",
+                "value": "cr519_SMEHub"
+            },
+            {
+                "key": "DefaultsAddedFlag",
+                "value": true
+            },
+            {
+                "key": "ChangedEntityTypes",
+                "value": [
+                    {
+                        "__type": "KeyValuePairOfstringstring:#System.Collections.Generic",
+                        "key": "ukho_externalnotification",
+                        "value": "Update"
+                    }
+                ]
+            }
+        ],
+        "Stage": 30,
+        "UserAzureActiveDirectoryObjectId": "349b02df-fca1-4a40-bddf-277d294fb307",
+        "UserId": "2937697b-81b9-e211-a1a0-984be17c9a93"
+    },
+    "PostEntityImages": [
+        {
+            "key": "AsynchronousStepPrimaryName",
+            "value": {
+                "Attributes": [
+                    {
+                        "key": "ukho_externalnotificationid",
+                        "value": "bd0ccbc8-2975-ec11-8943-002248818243"
+                    }
+                ],
+                "EntityState": null,
+                "FormattedValues": [],
+                "Id": "bd0ccbc8-2975-ec11-8943-002248818243",
+                "KeyAttributes": [],
+                "LogicalName": "ukho_externalnotification",
+                "RelatedEntities": [],
+                "RowVersion": null
+            }
+        }
+    ],
+    "PreEntityImages": [],
+    "PrimaryEntityId": "bd0ccbc8-2975-ec11-8943-002248818243",
+    "PrimaryEntityName": "ukho_externalnotification",
+    "RequestId": "004af0c9-73a5-4420-9bf9-b6b50f82e3cc",
+    "SecondaryEntityName": "none",
+    "SharedVariables": [
+        {
+            "key": "IsAutoTransact",
+            "value": true
+        },
+        {
+            "key": "x-ms-app-name",
+            "value": "cr519_SMEHub"
+        },
+        {
+            "key": "DefaultsAddedFlag",
+            "value": true
+        }
+    ],
+    "Stage": 40,
+    "UserAzureActiveDirectoryObjectId": "349b02df-fca1-4a40-bddf-277d294fb307",
+    "UserId": "2937697b-81b9-e211-a1a0-984be17c9a93"
+}

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/D365HttpPayloadValidationTest.cs
@@ -16,6 +16,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         private TestConfiguration TestConfig { get; set; }
         private D365Payload D365FssAvcsPayload { get; set; }
         private D365Payload D365FssMsiPayload { get; set; }
+        private D365Payload D365FssSencPayload { get; set; }
         private D365Payload D365ScsPayload { get; set; }
         private D365Payload D365ScsS100Payload { get; set; }
         private string EnsToken { get; set; }
@@ -34,15 +35,18 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
 
             string filePathFssAvcs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssAvcsPayloadFileName);
             string filePathFssMsi = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssMsiPayloadFileName);
+            string filePathFssSenc = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.FssSencPayloadFileName);
             string filePathScs = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsPayloadFileName);
             string filePathScsS100 = Path.Combine(Directory.GetCurrentDirectory(), TestConfig.PayloadFolder, TestConfig.ScsS100PayloadFileName);
 
             D365FssAvcsPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssAvcs), JOptions);
             D365FssMsiPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssMsi), JOptions);
+            D365FssSencPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathFssSenc), JOptions);
             D365ScsPayload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathScs), JOptions);
             D365ScsS100Payload = JsonSerializer.Deserialize<D365Payload>(await File.ReadAllTextAsync(filePathScsS100), JOptions);
             D365FssAvcsPayload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
             D365FssMsiPayload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
+            D365FssSencPayload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
             D365ScsPayload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
             D365ScsS100Payload.InputParameters[0].Value.Attributes[9].Value = string.Concat(TestConfig.StubBaseUri, TestConfig.WebhookUrlExtension);
 
@@ -76,6 +80,13 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssMsiPayload_ThenAcceptedStatusIsReturned()
         {
             HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssMsiPayload, EnsToken);
+            Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
+        }
+
+        [Test]
+        public async Task WhenICallTheEnsSubscriptionApiWithAValidD365FssSencPayload_ThenAcceptedStatusIsReturned()
+        {
+            HttpResponseMessage apiResponse = await EnsApiClient.PostEnsApiSubscriptionAsync(D365FssSencPayload, EnsToken);
             Assert.That((int)apiResponse.StatusCode, Is.EqualTo(202), $"Incorrect status code {apiResponse.StatusCode} is  returned, instead of the expected 202.");
         }
 

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/FunctionalTests/EnsEnterpriseEventServiceWebhookTest.cs
@@ -111,6 +111,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.FunctionalTests
         [TestCase("AENP", "fss-filesPublished-AvcsData", TestName = "Valid AENP Business Unit event")]
         [TestCase("ARCS", "fss-filesPublished-AvcsData", TestName = "Valid ARCS Business Unit event")]
         [TestCase("MaritimeSafetyInformation", "fss-filesPublished-MaritimeSafetyInformation", TestName = "Valid MaritimeSafetyInformation Business Unit event")]
+        [TestCase("SENC", "fss-filesPublished-SENC", TestName = "Valid SENC Business Unit event")]
         public async Task WhenICallTheEnsWebhookApiWithAValidFssJObjectBody_ThenOkStatusIsReturned(string businessUnit, string source)
         {
             const string subject = "83d08093-7a67-4b3a-b431-92ba42feaea0";

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/Helper/TestConfiguration.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/Helper/TestConfiguration.cs
@@ -10,6 +10,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.Helper
         public string PayloadFolder { get; set; }
         public string FssAvcsPayloadFileName { get; set; }
         public string FssMsiPayloadFileName { get; set; }
+        public string FssSencPayloadFileName { get; set; }
         public string ScsPayloadFileName { get; set; }
         public string ScsS100PayloadFileName { get; set; }
         public string EnsStorageConnectionString { get; set; }
@@ -42,6 +43,7 @@ namespace UKHO.ExternalNotificationService.API.FunctionalTests.Helper
             PayloadFolder = ConfigurationRoot.GetSection("PayloadFolder").Value;
             FssAvcsPayloadFileName = ConfigurationRoot.GetSection("FssAvcsPayloadFileName").Value;
             FssMsiPayloadFileName = ConfigurationRoot.GetSection("FssMsiPayloadFileName").Value;
+            FssSencPayloadFileName = ConfigurationRoot.GetSection("FssSencPayloadFileName").Value;
             ScsPayloadFileName = ConfigurationRoot.GetSection("ScsPayloadFileName").Value;
             ScsS100PayloadFileName = ConfigurationRoot.GetSection("ScsS100PayloadFileName").Value;
             EnsStorageConnectionString = ConfigurationRoot.GetSection("EnsStorageConnectionString").Value;

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <None Remove="D365PayloadTestData\D365FssSENCSamplePayload.json" />
     <None Remove="D365PayloadTestData\D365ScsS100SamplePayload.json" />
   </ItemGroup>
 
@@ -15,6 +16,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="D365PayloadTestData\D365FssAvcsSamplePayload.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="D365PayloadTestData\D365FssSencSamplePayload.json">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="D365PayloadTestData\D365ScsS100SamplePayload.json">

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
@@ -3,7 +3,7 @@
   "PayloadFolder": "D365PayloadTestData",
   "FssAvcsPayloadFileName": "D365FssAvcsSamplePayload.json",
   "FssMsiPayloadFileName": "D365FssMsiSamplePayload.json",
-  "FssSencPayloadFileName": "D365FssSencSamplePayload",
+  "FssSencPayloadFileName": "D365FssSencSamplePayload.json",
   "ScsPayloadFileName": "D365ScsSamplePayload.json",
   "ScsS100PayloadFileName": "D365ScsS100SamplePayload.json",
   "EnsStorageConnectionString": "",

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/appsettings.json
@@ -3,6 +3,7 @@
   "PayloadFolder": "D365PayloadTestData",
   "FssAvcsPayloadFileName": "D365FssAvcsSamplePayload.json",
   "FssMsiPayloadFileName": "D365FssMsiSamplePayload.json",
+  "FssSencPayloadFileName": "D365FssSencSamplePayload",
   "ScsPayloadFileName": "D365ScsSamplePayload.json",
   "ScsS100PayloadFileName": "D365ScsS100SamplePayload.json",
   "EnsStorageConnectionString": "",
@@ -42,6 +43,10 @@
       {
         "BusinessUnit": "MaritimeSafetyInformation",
         "Source": "fss-filesPublished-MaritimeSafetyInformation"
+      },
+      {
+        "BusinessUnit": "SENC",
+        "Source": "fss-filesPublished-SENC"
       }
     ],
     "EventHostName": "",

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/ConfigurationFiles/NotificationTypes.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/ConfigurationFiles/NotificationTypes.json
@@ -1,15 +1,19 @@
 {
     "EnsConfiguration": {
 
-        "NotificationTypes": [
-            {
-                "Name": "File Share Service - AVCS Data",
-                "TopicName": "fss-filesPublished-AvcsData"
-            },
-            {
-                "Name": "File Share Service - Maritime Safety Information",
-                "TopicName": "fss-filesPublished-MaritimeSafetyInformation"
-            },
+      "NotificationTypes": [
+        {
+          "Name": "File Share Service - AVCS Data",
+          "TopicName": "fss-filesPublished-AvcsData"
+        },
+        {
+          "Name": "File Share Service - Maritime Safety Information",
+          "TopicName": "fss-filesPublished-MaritimeSafetyInformation"
+        },
+        {
+          "Name": "File Share Service - SENC",
+          "TopicName": "fss-filesPublished-SENC"
+        },        
           {
             "Name": "ADDS Data Pipeline",
             "TopicName": "avcs-contentPublished"

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/appsettings.json
@@ -64,6 +64,10 @@
       {
         "BusinessUnit": "MaritimeSafetyInformation",
         "Source": "fss-filesPublished-MaritimeSafetyInformation"
+      },
+      {
+        "BusinessUnit": "SENC",
+        "Source": "fss-filesPublished-SENC"
       }
     ],
     "EventHostName": "",

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/BusinessUnitTypes.cs
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/Configuration/BusinessUnitTypes.cs
@@ -10,7 +10,8 @@ namespace UKHO.ExternalNotificationService.Common.Configuration
             "MaritimeSafetyInformation",
             "ADP",
             "AENP",
-            "ARCS"
+            "ARCS",
+            "SENC"
         };
     }
 }


### PR DESCRIPTION
This pull request adds support for testing and handling the new "File Share Service - SENC" notification type in the External Notification Service API functional tests. The changes introduce new test data, configuration updates, and test cases to ensure the SENC payload is properly validated and processed by the API.

**Support for SENC notification type:**

* Added new sample payload file `D365FssSencSamplePayload.json` for SENC and updated project configuration to include it as test content. [[1]](diffhunk://#diff-cda2dd59de0b87600e5c872aa7ba5a32dcf1ce1565e3646a8691d80bcfdb4695R1-R354) [[2]](diffhunk://#diff-9f5c3fa069f7035509c9dd6b2d0bc8ee8cfe93ce29b789feaff4cdcbdbfd89caR21-R23)
* Updated `appsettings.json` and `TestConfiguration` to include `FssSencPayloadFileName` for SENC payload support. [[1]](diffhunk://#diff-46fa418c29f82467d3e56da00946e7f807d311206e9906fc6a5811d4c0a93b1bR6) [[2]](diffhunk://#diff-30d41539b1d33469a0a95fca5d0449f07f73c767c23cc509b9931f99493615d0R13) [[3]](diffhunk://#diff-30d41539b1d33469a0a95fca5d0449f07f73c767c23cc509b9931f99493615d0R46)

**Functional test enhancements:**

* Extended `D365HttpPayloadValidationTest` to load and validate the SENC payload, including a new test case to verify that a valid SENC payload returns an accepted status. [[1]](diffhunk://#diff-a73a5050041212dd8754f907e34ea4ce6210843da3600fb40344eed69cddeea2R19) [[2]](diffhunk://#diff-a73a5050041212dd8754f907e34ea4ce6210843da3600fb40344eed69cddeea2R38-R49) [[3]](diffhunk://#diff-a73a5050041212dd8754f907e34ea4ce6210843da3600fb40344eed69cddeea2R86-R92)
* Added a new webhook test case for the SENC business unit in `EnsEnterpriseEventServiceWebhookTest`.

**Notification and event configuration updates:**

* Added SENC notification type and topic to `NotificationTypes.json` and updated event source configuration in `appsettings.json`. [[1]](diffhunk://#diff-62d1f61f0f24d92773ee5acbb256846e68f186bcdc2fa3662f2d7e7fe068f4e6R12-R15) [[2]](diffhunk://#diff-46fa418c29f82467d3e56da00946e7f807d311206e9906fc6a5811d4c0a93b1bR46-R49)