### PR TITLE
Merge feature/290762/main into main

### DIFF
--- a/Deployment/src/APIM/azure.tf
+++ b/Deployment/src/APIM/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.54.0"
     }
   }
 
-  required_version = "=1.9.6"
+  required_version = "=1.15.8"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.apim.tfplan"
@@ -15,4 +15,5 @@ terraform {
 
 provider "azurerm" {
   features {}
+  version = ">=4.54.0"
 }

--- a/Deployment/src/Modules/Webapp/main.tf
+++ b/Deployment/src/Modules/Webapp/main.tf
@@ -18,7 +18,7 @@ resource "azurerm_windows_web_app" "webapp_service" {
   site_config {
     application_stack {
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     
     always_on         = true
@@ -63,7 +63,7 @@ resource "azurerm_windows_web_app_slot" "staging" {
   site_config {
     application_stack {
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
     
     always_on         = true
@@ -106,7 +106,7 @@ resource "azurerm_windows_web_app" "stub_webapp_service" {
   site_config {
     application_stack {
       current_stack = "dotnet"
-      dotnet_version = "v8.0"
+      dotnet_version = "v10.0"
     }
 
     always_on         = true

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,11 +2,11 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "=3.116.0"
+      version = ">=4.54.0"
     }
   }
 
-  required_version = "=1.9.6"
+  required_version = "=1.15.8"
   backend "azurerm" {
     container_name = "tfstate"
     key            = "terraform.deployment.tfplan"
@@ -15,16 +15,19 @@ terraform {
 
 provider "azurerm" {
   features {}
+  version = ">=4.54.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
+  version = ">=4.54.0"
 }
 
 provider "azurerm" {
   features {}
   alias           = "coreservices"
   subscription_id = var.core_services_subscription_id
+  version = ">=4.54.0"
 }

--- a/Deployment/templates/build-test-publish.yml
+++ b/Deployment/templates/build-test-publish.yml
@@ -1,7 +1,7 @@
 parameters:
 - name: DotNetVersion
   type: string
-  default: '8.0.x'
+  default: '10.0.x'
 
 jobs:
 - job: UnitTestsAndCodeCoverage

--- a/Deployment/templates/functional-test-process.yml
+++ b/Deployment/templates/functional-test-process.yml
@@ -1,6 +1,9 @@
 parameters:
   - name: TestTitle
     type: string
+  - name: DotNetVersion
+    type: string
+    default: '10.0.x'
 
 steps:
   - task: DownloadBuildArtifacts@0
@@ -20,10 +23,10 @@ steps:
       jsonTargetFiles: '**/appsettings.json'
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 10.0.x sdk'
+    displayName: 'Use .NET ${{ parameters.DotNetVersion }} sdk'
     inputs:
       packageType: sdk
-      version: '10.0.x'
+      version: '${{ parameters.DotNetVersion }}'
 
   - task: DotNetCoreCLI@2
     displayName: "Run Functional tests"

--- a/Deployment/templates/functional-test-process.yml
+++ b/Deployment/templates/functional-test-process.yml
@@ -20,10 +20,10 @@ steps:
       jsonTargetFiles: '**/appsettings.json'
 
   - task: UseDotNet@2
-    displayName: 'Use .NET 8.0.x sdk'
+    displayName: 'Use .NET 10.0.x sdk'
     inputs:
       packageType: sdk
-      version: '8.0.x'
+      version: '10.0.x'
 
   - task: DotNetCoreCLI@2
     displayName: "Run Functional tests"

--- a/Deployment/terraform_conditional_run.ps1
+++ b/Deployment/terraform_conditional_run.ps1
@@ -15,7 +15,7 @@ cd $env:AGENT_BUILDDIRECTORY/terraformartifact/src
 terraform --version
 
 Write-output "Executing terraform scripts for deployment in $workSpace enviroment"
-terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
+terraform init -upgrade -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.tfplan"
 if ( !$? ) { echo "Something went wrong during terraform initialization"; throw "Error" }
 
 Write-output "Selecting workspace"

--- a/Deployment/terraform_conditional_run_apim.ps1
+++ b/Deployment/terraform_conditional_run_apim.ps1
@@ -11,7 +11,7 @@ terraform --version
 
 Write-output "Executing terraform scripts for APIM deployment in $workSpace enviroment..."
 
-terraform init -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.apim.ens.tfplan"
+terraform init -upgrade -backend-config="resource_group_name=$deploymentResourceGroupName" -backend-config="storage_account_name=$deploymentStorageAccountName" -backend-config="key=terraform.deployment.apim.ens.tfplan"
 if ( !$? ) { echo "Something went wrong during terraform initialization"; throw "Error" }
 
 Write-output "Selecting workspace..."

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.Tests/UKHO.D365CallbackDistributorStub.API.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>

--- a/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
+++ b/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API/UKHO.D365CallbackDistributorStub.API.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.49.0" />
+    <PackageReference Include="Azure.Core" Version="1.55.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="8.1.4" />
   </ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.FunctionalTests/UKHO.ExternalNotificationService.API.FunctionalTests.csproj
@@ -1,8 +1,8 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    
+    <TargetFramework>net10.0</TargetFramework>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -30,12 +30,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="8.0.20" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.0.9" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="10.0.9" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
       <PrivateAssets>all</PrivateAssets>
@@ -46,7 +46,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.UnitTests/UKHO.ExternalNotificationService.API.UnitTests.csproj
@@ -1,8 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
-    
+    <TargetFramework>net10.0</TargetFramework>
+
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -12,10 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.20" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="9.0.9" />
+    <PackageReference Include="FluentValidation" Version="12.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.9" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.10.0">
       <PrivateAssets>all</PrivateAssets>
@@ -26,6 +27,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.API.csproj
@@ -1,27 +1,26 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
     <PackageReference Include="Elastic.Apm.NetCoreAll" Version="1.34.1" />
     <PackageReference Include="Elastic.Clients.Elasticsearch" Version="9.1.10" />
     <PackageReference Include="FluentValidation" Version="12.0.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.20" />
-    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="8.0.20" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.77.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.HeaderPropagation" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.85.2" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
+    <PackageReference Include="SharpCompress" Version="0.49.1" />
+    <PackageReference Include="Snappier" Version="1.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common.UnitTests/UKHO.ExternalNotificationService.Common.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -12,7 +12,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.10.0">

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.Common/UKHO.ExternalNotificationService.Common.csproj
@@ -1,21 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.31.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="5.0.0" />
     <PackageReference Include="Azure.Messaging.EventHubs" Version="5.12.2" />
     <PackageReference Include="Azure.ResourceManager.EventGrid" Version="1.1.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
-    <PackageReference Include="Azure.Storage.Blobs" Version="12.26.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
+    <PackageReference Include="Azure.Storage.Blobs" Version="12.29.1" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="UKHO.Logging.EventHubLogProvider" Version="1.25196.1" />
   </ItemGroup>

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService.UnitTests/UKHO.ExternalNotificationService.Webjob.UnitTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>    
+    <TargetFramework>net10.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
@@ -12,8 +12,8 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="FakeItEasy" Version="8.3.0" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
     <PackageReference Include="NUnit" Version="4.4.0" />
     <PackageReference Include="NUnit.Analyzers" Version="4.10.0">

--- a/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
+++ b/UKHO.ExternalNotificationService.API/UKHO.ExternalNotificationService.SubscriptionService/UKHO.ExternalNotificationService.SubscriptionService.csproj
@@ -2,14 +2,14 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.4.0" />
-    <PackageReference Include="Azure.Identity" Version="1.17.0" />
-    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.8.0" />
-    <PackageReference Include="Azure.Storage.Queues" Version="12.24.0" />
+    <PackageReference Include="Azure.Extensions.AspNetCore.Configuration.Secrets" Version="1.5.1" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.11.0" />
+    <PackageReference Include="Azure.Storage.Queues" Version="12.27.1" />
     <PackageReference Include="Elastic.Apm" Version="1.34.1" />
     <PackageReference Include="Elastic.Apm.Azure.Storage" Version="1.34.1" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.23.0" />
@@ -17,19 +17,18 @@
     <PackageReference Include="Microsoft.Azure.WebJobs.Extensions.Storage" Version="5.3.6" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Host.Storage" Version="5.0.1" />
     <PackageReference Include="Microsoft.Azure.WebJobs.Logging.ApplicationInsights" Version="3.0.41" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="9.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Http.Polly" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
     <PackageReference Include="runtime.native.System.Net.Security" Version="4.3.1" />
     <PackageReference Include="Serilog" Version="4.3.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="9.0.2" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.Text.Json" Version="9.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -47,7 +47,7 @@ variables:
   - name: UKHOAssemblyCopyright
     value: "Copyright © UK Hydrographic Office"
   - name: Container
-    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.9.6"
+    value: "ukhydrographicoffice/terraform-azure-powershell-unzip:1.15.8"
   - name: DeploymentPool
     value: "Mare Nectaris"
   - name: WindowsPool1
@@ -57,7 +57,7 @@ variables:
   - name: snykAbzuOrganizationId
     value: aeb7543b-8394-457c-8334-a31493d8910d
   - name: DotNetSdkVersion
-    value: "8.0.x"
+    value: "10.0.x"
 
 resources:
   repositories:


### PR DESCRIPTION
This pull request upgrades the solution to use .NET 10 and updates several dependencies and infrastructure components to maintain compatibility and improve security. It also updates Terraform and Azure provider versions, and ensures build and deployment scripts are aligned with these changes.

**.NET and Dependency Upgrades:**

* Upgraded all project files (`.csproj`) to target `.NET 10.0` instead of `.NET 8.0`, including main projects, unit tests, and functional tests. [[1]](diffhunk://#diff-fc7701b08d1a03598a4959c4d20b59f3989cbb910cd0810a4ac86dc0cb0b210bL4-R4) [[2]](diffhunk://#diff-0b0e7957a800238d09662d6f93b32bf049a11658b9f828be26696e2e4a024773L4-R10) [[3]](diffhunk://#diff-9f5c3fa069f7035509c9dd6b2d0bc8ee8cfe93ce29b789feaff4cdcbdbfd89caL1-R4) [[4]](diffhunk://#diff-1abb0d82a6abc561953c5d0d7e4d7355f9f18fd69179ac2a3105a2d67862b356L4-R4) [[5]](diffhunk://#diff-0c984c46484a936d96c09f09c80306fff1980fe6920b4d44c258ad7d97a92e76L4-R4) [[6]](diffhunk://#diff-39004f25aaeb153639967bdc92c7bff373375816d07aa2a6ef85951fa32dee24L4-R15) [[7]](diffhunk://#diff-c08f36ef3823e0f5de26f5972f6750cd4fc7d8f8b33f20204b7f98808f68dec5L4-R4)
* Updated NuGet package dependencies to the latest compatible versions, including Azure SDKs, Microsoft.Extensions libraries, and others for both production and test projects. [[1]](diffhunk://#diff-0b0e7957a800238d09662d6f93b32bf049a11658b9f828be26696e2e4a024773L4-R10) [[2]](diffhunk://#diff-9f5c3fa069f7035509c9dd6b2d0bc8ee8cfe93ce29b789feaff4cdcbdbfd89caL33-R38) [[3]](diffhunk://#diff-1abb0d82a6abc561953c5d0d7e4d7355f9f18fd69179ac2a3105a2d67862b356L15-R19) [[4]](diffhunk://#diff-1abb0d82a6abc561953c5d0d7e4d7355f9f18fd69179ac2a3105a2d67862b356R30-R31) [[5]](diffhunk://#diff-fd80a1fd5028fe7a4703ca609d1b47401f6e0fb2c655fe231bc6af54fdc665b1L4-R23) [[6]](diffhunk://#diff-0c984c46484a936d96c09f09c80306fff1980fe6920b4d44c258ad7d97a92e76L15-R15) [[7]](diffhunk://#diff-39004f25aaeb153639967bdc92c7bff373375816d07aa2a6ef85951fa32dee24L4-R15) [[8]](diffhunk://#diff-c08f36ef3823e0f5de26f5972f6750cd4fc7d8f8b33f20204b7f98808f68dec5L15-R16)

**Terraform and Azure Provider Updates:**

* Increased required Terraform version from `1.9.6` to `1.15.8` and AzureRM provider version to `>=4.54.0` in all relevant `.tf` files and provider blocks. [[1]](diffhunk://#diff-c4ed35bf4ec0fe1d0a0446a79e11ef2d7fb3d3103212a79151a2ef6ffc419005L5-R9) [[2]](diffhunk://#diff-c4ed35bf4ec0fe1d0a0446a79e11ef2d7fb3d3103212a79151a2ef6ffc419005R18) [[3]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL5-R9) [[4]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbR18-R32)
* Updated `terraform init` commands in deployment scripts to use the `-upgrade` flag, ensuring providers are updated during initialization. [[1]](diffhunk://#diff-1baf085eedf7cbe467a35d9eca2277c8693455926c63002fd5b51f26608931daL18-R18) [[2]](diffhunk://#diff-8279e305f924e2d044673fba71f5244b96acddd3dca7a69581fc7c6d30d4b922L14-R14)

**Application and Pipeline Configuration:**

* Updated web app and slot configurations in Terraform to use `dotnet_version = "v10.0"` for deployment resources. [[1]](diffhunk://#diff-e977d3422b6caa7c2a598db3741ab480f8a25de03b7ba959fe917318452b5493L21-R21) [[2]](diffhunk://#diff-e977d3422b6caa7c2a598db3741ab480f8a25de03b7ba959fe917318452b5493L66-R66) [[3]](diffhunk://#diff-e977d3422b6caa7c2a598db3741ab480f8a25de03b7ba959fe917318452b5493L109-R109)
* Changed pipeline YAML templates to default to .NET 10 for build and test jobs. [[1]](diffhunk://#diff-55bf4d584d9faa3ba8d71cf75eba0b6190e050db58dfd349e1a2c31ac279ee4fL4-R4) [[2]](diffhunk://#diff-0845a203f3b9ef1bc95645d99b659f7bb433c9970d74b1f9e0a3f246382ad759R4-R6) [[3]](diffhunk://#diff-0845a203f3b9ef1bc95645d99b659f7bb433c9970d74b1f9e0a3f246382ad759L23-R29)

These changes ensure the codebase, infrastructure, and pipelines are all aligned to use .NET 10 and the latest Azure and Terraform tooling.