### PR TITLE
Rolled back and fixed azurerm version

### DIFF
--- a/Deployment/src/APIM/azure.tf
+++ b/Deployment/src/APIM/azure.tf
@@ -15,5 +15,4 @@ terraform {
 
 provider "azurerm" {
   features {}
-  version = "=4.81.0"
 }

--- a/Deployment/src/APIM/azure.tf
+++ b/Deployment/src/APIM/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=4.54.0"
+      version = "=4.81.0"
     }
   }
 
@@ -15,5 +15,5 @@ terraform {
 
 provider "azurerm" {
   features {}
-  version = ">=4.54.0"
+  version = "=4.81.0"
 }

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">=4.54.0"
+      version = "=4.81.0"
     }
   }
 
@@ -15,19 +15,19 @@ terraform {
 
 provider "azurerm" {
   features {}
-  version = ">=4.54.0"
+  version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
-  version = ">=4.54.0"
+  version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias           = "coreservices"
   subscription_id = var.core_services_subscription_id
-  version = ">=4.54.0"
+  version = "=4.81.0"
 }

--- a/Deployment/src/azure.tf
+++ b/Deployment/src/azure.tf
@@ -15,19 +15,16 @@ terraform {
 
 provider "azurerm" {
   features {}
-  version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias = "build_agent"
   subscription_id = var.agent_subscription_id
-  version = "=4.81.0"
 }
 
 provider "azurerm" {
   features {}
   alias           = "coreservices"
   subscription_id = var.core_services_subscription_id
-  version = "=4.81.0"
 }


### PR DESCRIPTION
This pull request updates the required version of the `azurerm` Terraform provider throughout the deployment configuration. All references to the provider are now pinned to the exact version `4.81.0`, instead of allowing any version greater than or equal to `4.54.0`. This change ensures consistent and predictable behavior across deployments.

**Provider version pinning:**

* [`Deployment/src/APIM/azure.tf`](diffhunk://#diff-c4ed35bf4ec0fe1d0a0446a79e11ef2d7fb3d3103212a79151a2ef6ffc419005L5-R5): Updated both the `required_providers` block and the `provider "azurerm"` block to require exactly version `4.81.0` instead of `>=4.54.0`. [[1]](diffhunk://#diff-c4ed35bf4ec0fe1d0a0446a79e11ef2d7fb3d3103212a79151a2ef6ffc419005L5-R5) [[2]](diffhunk://#diff-c4ed35bf4ec0fe1d0a0446a79e11ef2d7fb3d3103212a79151a2ef6ffc419005L18-R18)
* [`Deployment/src/azure.tf`](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL5-R5): Updated all `azurerm` provider definitions (default, `build_agent`, and `coreservices` aliases) and the `required_providers` block to require exactly version `4.81.0` instead of `>=4.54.0`. [[1]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL5-R5) [[2]](diffhunk://#diff-9994a376c8e3601a2876b0aaa3185178027f19cb3d20506b963cce999d1b4dbbL18-R32)