### PR TITLE
adding az cli task to force update of windows fx version

### DIFF
--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -50,6 +50,19 @@ steps:
       enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
 
+  - task: AzureCLI@2
+    displayName: "Set App Service runtime to .NET 10 (prod + staging)"
+    inputs:
+      azureSubscription: "${{ parameters.AzureSubscription }}"
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: | 
+        az webapp config set `
+          --resource-group "$(ResourceGroup)" `
+          --name "$(WEB_APP_NAME)" `
+          --slot "$(WEB_APP_SLOT_NAME)" `
+          --windows-fx-version "DOTNET|10.0"
+
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: Staging slot"
     inputs:
@@ -92,19 +105,6 @@ steps:
       xmlTransformationRules: ''
       enableXmlTransform: false
       jsonTargetFiles: '**/appsettings.json'
-
-  - task: AzureCLI@2
-    displayName: "Set App Service runtime to .NET 10 (prod + staging)"
-    inputs:
-      azureSubscription: "${{ parameters.AzureSubscription }}"
-      scriptType: pscore
-      scriptLocation: inlineScript
-      inlineScript: | 
-        az webapp config set `
-          --resource-group "$(ResourceGroup)" `
-          --name "$(WEB_APP_NAME)" `
-          --slot "$(WEB_APP_SLOT_NAME)" `
-          --windows-fx-version "DOTNET|10.0"
 
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: ens-$(Environment)-stub-webapp"

--- a/Deployment/templates/continuous-deployment.yml
+++ b/Deployment/templates/continuous-deployment.yml
@@ -91,7 +91,20 @@ steps:
       folderPath: '$(Pipeline.Workspace)/StubWebAPI/*.zip'
       xmlTransformationRules: ''
       enableXmlTransform: false
-      jsonTargetFiles: '**/appsettings.json'           
+      jsonTargetFiles: '**/appsettings.json'
+
+  - task: AzureCLI@2
+    displayName: "Set App Service runtime to .NET 10 (prod + staging)"
+    inputs:
+      azureSubscription: "${{ parameters.AzureSubscription }}"
+      scriptType: pscore
+      scriptLocation: inlineScript
+      inlineScript: | 
+        az webapp config set `
+          --resource-group "$(ResourceGroup)" `
+          --name "$(WEB_APP_NAME)" `
+          --slot "$(WEB_APP_SLOT_NAME)" `
+          --windows-fx-version "DOTNET|10.0"
 
   - task: AzureWebApp@1
     displayName: "Azure App Deploy: ens-$(Environment)-stub-webapp"


### PR DESCRIPTION
This pull request introduces an additional deployment step to the continuous deployment pipeline to explicitly set the App Service runtime to .NET 10 for both production and staging environments. This ensures that the deployed web application runs on the correct .NET version before deployment.

Deployment pipeline enhancements:

* Added a new `AzureCLI@2` task in `Deployment/templates/continuous-deployment.yml` to set the App Service runtime to `.NET 10` using the `az webapp config set` command, ensuring compatibility with the target framework before the application is deployed.